### PR TITLE
Changes in API.createAction

### DIFF
--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -12,11 +12,19 @@ const urls = Config.apis.urls;
 
 type Method = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 
-export const createAction = (method: Method, url: string, queryParams?: any, data?: any): Action => ({
-    method,
-    endpoint: url + (queryParams ? '?' + new URLSearchParams(queryParams).toString() : ''),
-    body: data
-});
+export const createAction = (method: Method, url: string, queryParams?: any, data?: any): Action => {
+    const parsedURL = new URL(url, 'http://dummybase');
+    const querySeparator = parsedURL.searchParams.toString() === '' ? '?' : '&';
+    const queryString = queryParams ? new URLSearchParams(queryParams).toString() : '';
+
+    const endpoint = url + (queryString === '' ? '' : querySeparator + queryString);
+
+    return {
+        method,
+        endpoint,
+        body: data
+    };
+};
 
 export const useNewQuery = <T>(method: Method, url: string, initFetch?: boolean, queryParams?: any, data?: any) =>
     useQuery<T>(createAction(method, url, queryParams, data), initFetch);

--- a/src/services/__tests__/Api.test.ts
+++ b/src/services/__tests__/Api.test.ts
@@ -1,0 +1,54 @@
+import { createAction } from '../Api';
+
+describe('src/services/Api', () => {
+
+    it('createAction sets the method', () => {
+        const action = createAction('PUT', 'http://redhat.com');
+        expect(action.method).toEqual('PUT');
+    });
+
+    it('createAction builds an absolute url', () => {
+        const action = createAction('GET', 'http://redhat.com');
+        expect(action.endpoint).toEqual('http://redhat.com');
+    });
+
+    it('createAction builds relative urls', () => {
+        const action = createAction('GET', '/api/v1.0/policies');
+        expect(action.endpoint).toEqual('/api/v1.0/policies');
+    });
+
+    it('createAction parse relative urls and adds query params', () => {
+        const action = createAction('GET', '/api/v1.0/policies', { foo: 'max' });
+        expect(action.endpoint).toEqual('/api/v1.0/policies?foo=max');
+    });
+
+    it('createAction parse relative urls and handle empty query params', () => {
+        const action = createAction('GET', '/api/v1.0/policies', { });
+        expect(action.endpoint).toEqual('/api/v1.0/policies');
+    });
+
+    it('createAction builds urls with query params', () => {
+        const action = createAction('GET', '/api/v1.0/policies?search=foo');
+        expect(action.endpoint).toEqual('/api/v1.0/policies?search=foo');
+    });
+
+    it('createAction builds urls with query params and adds query params', () => {
+        const action = createAction('GET', '/api/v1.0/policies?search=foo', { foo: 'max' });
+        expect(action.endpoint).toEqual('/api/v1.0/policies?search=foo&foo=max');
+    });
+
+    it('createAction sets the body as the passed data', () => {
+        const action = createAction('POST', '/api/v1.0/policies', {}, {
+            foo: 'im the data',
+            bar: {
+                baz: 'just passed along'
+            }
+        });
+        expect(action.body).toEqual({
+            foo: 'im the data',
+            bar: {
+                baz: 'just passed along'
+            }
+        });
+    });
+});

--- a/src/services/__tests__/useSavePolicy.test.ts
+++ b/src/services/__tests__/useSavePolicy.test.ts
@@ -24,7 +24,7 @@ describe('src/services/useSavePolicy', () => {
             isEnabled: true
         });
 
-        expect(action.endpoint).toEqual('/api/policies/v1.0/policies/foo-bar?');
+        expect(action.endpoint).toEqual('/api/policies/v1.0/policies/foo-bar');
         expect(action.method).toEqual('PUT');
     });
 });


### PR DESCRIPTION
  - Adds tests for API.createAction
  - Supports URL with queryParams
  - Returns URLs without trailing '?'