### PR TITLE
POL-193 Change text for email warning on landing page

### DIFF
--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -21,6 +21,7 @@ import { PolicyFilterColumn } from '../../types/Policy/PolicyPaging';
 import { EmailOptIn } from '../../components/EmailOptIn/EmailOptIn';
 import { Messages } from '../../properties/Messages';
 import { useBulkChangePolicyEnabledMutation } from '../../services/useChangePolicyEnabled';
+import { style } from 'typestyle';
 
 type ListPageProps = {};
 
@@ -38,6 +39,10 @@ type PolicyWizardStateClosed = {
 } & Partial<PolicyWizardStateBase>;
 
 type PolicyWizardState = PolicyWizardStateClosed | PolicyWizardStateOpen;
+
+const emailOptinPageClassName = style({
+    paddingBottom: 0
+});
 
 const ListPage: React.FunctionComponent<ListPageProps> = (_props) => {
 
@@ -208,7 +213,7 @@ const ListPage: React.FunctionComponent<ListPageProps> = (_props) => {
             !appContext.userSettings.dailyEmail &&
             getPoliciesQuery.payload &&
             getPoliciesQuery.payload.find(p => p.actions.find(a => a.type === ActionType.EMAIL)) && (
-                <PageSection>
+                <PageSection className={ emailOptinPageClassName }>
                     <EmailOptIn content={ Messages.pages.listPage.emailOptIn } />
                 </PageSection>
             )}

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -10,8 +10,7 @@ const actionTypeToText: Record<ActionType, string> = {
 const MutableMessages = {
     pages: {
         listPage: {
-            emailOptIn: 'One or more of your policies have an email alert, but you have not opted into receiving alert emails from' +
-                ' Policies. You will not receive any emails from your policies.'
+            emailOptIn: 'One or more of your policies have an email alert. To receive these emails, opt in to email alerts.'
         }
     },
     components: {


### PR DESCRIPTION

![Screenshot_2020-04-06_12-28-21](https://user-images.githubusercontent.com/3845764/78587215-3c96b980-7802-11ea-908d-dbfa3edb56a0.png)

 - Fixes double space

Ignore the title, that's covered in #97 