### PR TITLE
Route all the /api/policies/ requests to localhost

### DIFF
--- a/profiles/local-frontend-and-api.ts
+++ b/profiles/local-frontend-and-api.ts
@@ -11,7 +11,7 @@ routes[`/${SECTION}/${APP_ID}`]      = { host: `https://localhost:${FRONTEND_POR
 routes[`/beta/apps/${APP_ID}`]       = { host: `https://localhost:${FRONTEND_PORT}` };
 routes[`/apps/${APP_ID}`]            = { host: `https://localhost:${FRONTEND_PORT}` };
 
-routes[`/api/policies/v1.0`] = { host: `http://localhost:${API_PORT}` };
+routes[`/api/policies/`] = { host: `http://localhost:${API_PORT}` };
 
 module.exports = {
     routes,


### PR DESCRIPTION
(When using the proxy for development)