### PR TITLE
 POL-250 Implemented smart query into our list page to know if we have more elements or not

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-jest": "^23.8.0",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^2.3.0",
+    "fetch-mock": "9.4.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "node-sass": "^4.13.0",

--- a/src/hooks/__tests__/usePaginated.test.tsx
+++ b/src/hooks/__tests__/usePaginated.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useNewPaginatedQuery } from '../usePaginated';
+import { actionBuilder } from '../../services/Api/ActionBuilder';
+import fetchMock from 'fetch-mock';
+import { ClientContextProvider, createClient } from 'react-fetching-library';
+
+describe('src/hooks/usePaginated', () => {
+
+    const Wrapper: React.FunctionComponent = (props) => {
+        return <ClientContextProvider client={ createClient() }>{ props.children }</ClientContextProvider>
+    };
+
+    it('Sets count to undefined if TotalCount header not found', async () => {
+        jest.useFakeTimers();
+        fetchMock.get('http://localhost', {
+            headers: {
+                NotTotalCount: 'stuff'
+            }
+        });
+
+        const { result } = renderHook(
+            () => useNewPaginatedQuery(actionBuilder('GET', 'http://localhost').build()),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.count).toBe(null);
+        fetchMock.restore();
+    });
+
+    it('Sets count to 5 if TotalCount header is "5"', async () => {
+        jest.useFakeTimers();
+        fetchMock.get('http://localhost', {
+            headers: {
+                TotalCount: '5'
+            }
+        });
+
+        const { result } = renderHook(
+            () => useNewPaginatedQuery(actionBuilder('GET', 'http://localhost').build()),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.count).toBe(5);
+        fetchMock.restore();
+    });
+});

--- a/src/hooks/__tests__/usePaginated.test.tsx
+++ b/src/hooks/__tests__/usePaginated.test.tsx
@@ -8,7 +8,7 @@ import { ClientContextProvider, createClient } from 'react-fetching-library';
 describe('src/hooks/usePaginated', () => {
 
     const Wrapper: React.FunctionComponent = (props) => {
-        return <ClientContextProvider client={ createClient() }>{ props.children }</ClientContextProvider>
+        return <ClientContextProvider client={ createClient() }>{ props.children }</ClientContextProvider>;
     };
 
     it('Sets count to undefined if TotalCount header not found', async () => {

--- a/src/hooks/usePaginated.ts
+++ b/src/hooks/usePaginated.ts
@@ -1,5 +1,8 @@
-import { UsePaginatedQueryResponse } from '../utils/ApiUtils';
-import { Action, QueryResponse, useQuery } from 'react-fetching-library';
+import { Action, QueryResponse, useQuery, UseQueryResponse } from 'react-fetching-library';
+
+export type UsePaginatedQueryResponse<T> = UseQueryResponse<T> & {
+    count: number;
+};
 
 const decorate = <T, R>(data: T, decorator: (data: T) => R) => {
     return decorator(data);

--- a/src/pages/ListPage/__tests__/useGetListPagesPolicies.test.tsx
+++ b/src/pages/ListPage/__tests__/useGetListPagesPolicies.test.tsx
@@ -10,7 +10,7 @@ import { paginatedActionBuilder } from '../../../services/Api/PaginatedActionBui
 describe('src/hooks/usePaginated', () => {
 
     const Wrapper: React.FunctionComponent = (props) => {
-        return <ClientContextProvider client={ createClient() }>{ props.children }</ClientContextProvider>
+        return <ClientContextProvider client={ createClient() }>{ props.children }</ClientContextProvider>;
     };
 
     const failIfNoHttpCallMatched = () => {

--- a/src/pages/ListPage/__tests__/useGetListPagesPolicies.tsx
+++ b/src/pages/ListPage/__tests__/useGetListPagesPolicies.tsx
@@ -1,0 +1,373 @@
+import * as React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import fetchMock, { UNMATCHED } from 'fetch-mock';
+import { ClientContextProvider, createClient } from 'react-fetching-library';
+import { useGetListPagePolicies } from '../useGetListPagePolicies';
+import { Page } from '../../../types/Page';
+import Config from '../../../config/Config';
+import { paginatedActionBuilder } from '../../../services/Api/PaginatedActionBuilder';
+
+describe('src/hooks/usePaginated', () => {
+
+    const Wrapper: React.FunctionComponent = (props) => {
+        return <ClientContextProvider client={ createClient() }>{ props.children }</ClientContextProvider>
+    };
+
+    const failIfNoHttpCallMatched = () => {
+        const calls = fetchMock.calls(UNMATCHED).filter(c => c.isUnmatched);
+        if (calls.length > 0) {
+            throw new Error(`Found ${ calls.length } unmatched calls, maybe you forgot to mock? : ${calls.map(c => c.request?.url || c['0'])}`);
+        }
+    };
+
+    beforeEach(() => fetchMock.restore());
+    afterEach(() => failIfNoHttpCallMatched());
+
+    it('hasPolicies is true when fetching the default page and status is 200', async () => {
+        jest.useFakeTimers();
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(Page.defaultPage())
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 200
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(Page.defaultPage()),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.hasPolicies).toBe(true);
+    });
+
+    it('hasPolicies is false when fetching the default page and status is 404', async () => {
+        jest.useFakeTimers();
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(Page.defaultPage())
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 404
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(Page.defaultPage()),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.hasPolicies).toBe(false);
+    });
+
+    it('hasPolicies is undefined before fetching', async () => {
+        jest.useFakeTimers();
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(Page.defaultPage())
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 404
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(Page.defaultPage()),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        expect(result.current.hasPolicies).toBe(undefined);
+    });
+
+    it('hasPolicies is undefined when fetching the default page and status is not 200 or 404', async () => {
+        jest.useFakeTimers();
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(Page.defaultPage())
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 500
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(Page.defaultPage()),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.hasPolicies).toBe(undefined);
+    });
+
+    it('hasPolicies is undefined when fetching the default page and status is 200, then fetching again and status is not 200 or 404', async () => {
+        jest.useFakeTimers();
+        const matcher = paginatedActionBuilder('GET', Config.apis.urls.policies)
+        .page(Page.defaultPage())
+        .build()
+        .endpoint;
+
+        fetchMock.getOnce(matcher,
+            {
+                headers: {},
+                status: 200
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(Page.defaultPage()),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(fetchMock.calls(matcher).length).toBe(1);
+        expect(result.current.hasPolicies).toBe(true);
+
+        fetchMock.getOnce(matcher,
+            {
+                headers: {},
+                status: 500
+            },
+            {
+                overwriteRoutes: true
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(fetchMock.calls(matcher).length).toBe(2);
+        expect(result.current.hasPolicies).toBe(undefined);
+    });
+
+    it('hasPolicies is true when fetching the second page and status is 404 if any policy in unfiltered first page', async () => {
+        jest.useFakeTimers();
+        const secondPage = Page.of(2, Page.defaultPage().size);
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(secondPage)
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 404
+            }
+        ).getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(Page.of(1, 1))
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 200
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(secondPage),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.hasPolicies).toBe(true);
+    });
+
+    it('hasPolicies is false when fetching the second page and status is 404 if no policy in unfiltered first page', async () => {
+        jest.useFakeTimers();
+        const secondPage = Page.of(2, Page.defaultPage().size);
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(secondPage)
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 404
+            }
+        ).getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(Page.of(1, 1))
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 404
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(secondPage),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.hasPolicies).toBe(false);
+    });
+
+    it('hasPolicies is undefined when fetching the second page and status is not 200 or 404', async () => {
+        jest.useFakeTimers();
+        const secondPage = Page.of(2, Page.defaultPage().size);
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(secondPage)
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 500
+            }
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(secondPage),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+            await jest.runAllTimers();
+        });
+
+        expect(result.current.hasPolicies).toBe(undefined);
+    });
+
+    it('hasPolicies is undefined when fetching the second page with status is 404 and query for first page yields other than 200 or 404',
+        async () => {
+            jest.useFakeTimers();
+            const secondPage = Page.of(2, Page.defaultPage().size);
+            fetchMock.getOnce(
+                paginatedActionBuilder('GET', Config.apis.urls.policies)
+                .page(secondPage)
+                .build()
+                .endpoint,
+                {
+                    headers: {},
+                    status: 404
+                }
+            ).getOnce(
+                paginatedActionBuilder('GET', Config.apis.urls.policies)
+                .page(Page.of(1, 1))
+                .build()
+                .endpoint,
+                {
+                    headers: {},
+                    status: 500
+                }
+            );
+
+            const { result } = renderHook(
+                () => useGetListPagePolicies(secondPage),
+                {
+                    wrapper: Wrapper
+                }
+            );
+
+            await act(async () => {
+                result.current.query();
+                await jest.runAllTimers();
+            });
+
+            expect(result.current.hasPolicies).toBe(undefined);
+        }
+    );
+
+    it('hasPolicies is undefined when fetching the second page with status is 404 prior to fetching first page', async () => {
+        jest.useFakeTimers();
+        const secondPage = Page.of(2, Page.defaultPage().size);
+
+        let resolver;
+        const firstPagePromise = new Promise(resolve => {
+            resolver = resolve;
+        });
+
+        fetchMock.getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(secondPage)
+            .build()
+            .endpoint,
+            {
+                headers: {},
+                status: 404
+            }
+        ).getOnce(
+            paginatedActionBuilder('GET', Config.apis.urls.policies)
+            .page(Page.of(1, 1))
+            .build()
+            .endpoint,
+            firstPagePromise
+        );
+
+        const { result } = renderHook(
+            () => useGetListPagePolicies(secondPage),
+            {
+                wrapper: Wrapper
+            }
+        );
+
+        await act(async () => {
+            result.current.query();
+        });
+
+        expect(result.current.hasPolicies).toBe(undefined);
+        await act(async () => {
+            await resolver({
+                headers: {},
+                status: 404
+            });
+        });
+
+        expect(result.current.hasPolicies).toBe(false);
+    });
+});

--- a/src/pages/ListPage/useGetListPagePolicies.ts
+++ b/src/pages/ListPage/useGetListPagePolicies.ts
@@ -1,0 +1,79 @@
+import { useGetPoliciesQuery, useHasPoliciesQuery } from '../../services/useGetPolicies';
+import { Page } from '../../types/Page';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface UseGetListPagePoliciesResponse extends ReturnType<typeof useGetPoliciesQuery> {
+    hasPolicies: boolean | undefined;
+}
+
+export const useGetListPagePolicies = (page: Page): UseGetListPagePoliciesResponse => {
+    const getPoliciesQuery = useGetPoliciesQuery(page, false);
+    const hasPoliciesParametrizedQuery = useHasPoliciesQuery();
+    const [ hasPolicies, setHasPolicies ] = useState<boolean>();
+
+    useEffect(() => {
+        if (getPoliciesQuery.status === 200) {
+            setHasPolicies(true);
+        } else if (getPoliciesQuery.status === 404) {
+            setHasPolicies(false);
+        }
+    }, [ getPoliciesQuery.status ]);
+
+    const noFiltersAndFirstPage: boolean = useMemo(() => {
+        return !page.hasFilter() && page.index === 1;
+    }, [ page ]);
+
+    const query = useCallback(() => {
+        const localQuery = getPoliciesQuery.query;
+        const hasPoliciesQuery = hasPoliciesParametrizedQuery.query;
+
+        if (noFiltersAndFirstPage) {
+            return localQuery();
+        } else {
+            return localQuery().then(response => {
+                if (response.status === 404) {
+                    setHasPolicies(undefined);
+                    hasPoliciesQuery().then(r => {
+                        if (r.status === 404) {
+                            setHasPolicies(false);
+                        } else if (r.status === 200) {
+                            setHasPolicies(true);
+                        }
+
+                        return response;
+                    });
+                }
+
+                return response;
+            });
+        }
+    }, [ getPoliciesQuery.query, hasPoliciesParametrizedQuery.query, noFiltersAndFirstPage ]);
+
+    const abort = useCallback(() => {
+        const abortPolicyQuery = getPoliciesQuery.abort;
+        const abortHasPolicies = hasPoliciesParametrizedQuery.abort;
+
+        abortPolicyQuery();
+        abortHasPolicies();
+    }, [ getPoliciesQuery.abort, hasPoliciesParametrizedQuery.abort ]);
+
+    const reset = useCallback(() => {
+        const resetPolicyQuery = getPoliciesQuery.reset;
+        const resetHasPolicies = hasPoliciesParametrizedQuery.reset;
+
+        resetPolicyQuery();
+        resetHasPolicies();
+    }, [ getPoliciesQuery.reset, hasPoliciesParametrizedQuery.reset ]);
+
+    return {
+        ...getPoliciesQuery,
+        query,
+        abort,
+        reset,
+        status: getPoliciesQuery.status,
+        loading: hasPoliciesParametrizedQuery.loading || getPoliciesQuery.loading,
+        errorObject: hasPoliciesParametrizedQuery.errorObject || getPoliciesQuery.errorObject,
+        error: hasPoliciesParametrizedQuery.error || getPoliciesQuery.error,
+        hasPolicies
+    };
+};

--- a/src/pages/ListPage/useGetListPagePolicies.ts
+++ b/src/pages/ListPage/useGetListPagePolicies.ts
@@ -1,6 +1,6 @@
 import { useGetPoliciesQuery, useHasPoliciesQuery } from '../../services/useGetPolicies';
 import { Page } from '../../types/Page';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 export interface UseGetListPagePoliciesResponse extends ReturnType<typeof useGetPoliciesQuery> {
     hasPolicies: boolean | undefined;

--- a/src/services/useGetPolicies.ts
+++ b/src/services/useGetPolicies.ts
@@ -1,11 +1,12 @@
 import { Page } from '../types/Page';
-import { UsePaginatedQueryResponse, useTransformQueryResponse } from '../utils/ApiUtils';
+import { useTransformQueryResponse } from '../utils/ApiUtils';
 import { Policy } from '../types/Policy';
-import { useNewPaginatedQuery } from '../hooks';
+import { useNewPaginatedQuery, UsePaginatedQueryResponse } from '../hooks';
 import { PagedServerPolicyResponse } from '../types/Policy/Policy';
 import { paginatedActionBuilder } from './Api/PaginatedActionBuilder';
 import { toPolicies } from '../utils/PolicyAdapter';
 import Config from '../config/Config';
+import { useQuery } from 'react-fetching-library';
 
 const urls = Config.apis.urls;
 
@@ -15,5 +16,20 @@ export const useGetPoliciesQuery = (page?: Page, initFetch?: boolean): UsePagina
     return useTransformQueryResponse(
         useNewPaginatedQuery<PagedServerPolicyResponse>(actionCreator(page), initFetch),
         toPolicies
+    );
+};
+
+const policiesToBooleanAdapter = (pagedPolicyResponse: PagedServerPolicyResponse) => {
+    return pagedPolicyResponse.data?.length;
+};
+
+export const hasPoliciesQueryActionCreator = () => {
+    return paginatedActionBuilder('GET', urls.policies).page(Page.of(1, 1)).build();
+};
+
+export const useHasPoliciesQuery = () => {
+    return useTransformQueryResponse(
+        useQuery<PagedServerPolicyResponse>(hasPoliciesQueryActionCreator(), false),
+        policiesToBooleanAdapter
     );
 };

--- a/src/types/Page.ts
+++ b/src/types/Page.ts
@@ -18,6 +18,10 @@ export class Page {
         this.sort = sort;
     }
 
+    public hasFilter() {
+        return this.filter !== undefined  && this.filter.elements.length > 0;
+    }
+
     static of(index: number, size?: number, filter?: Filter, sort?: Sort) {
         return new Page(index, size, filter, sort);
     }

--- a/src/utils/ApiUtils.ts
+++ b/src/utils/ApiUtils.ts
@@ -1,25 +1,25 @@
 import * as React from 'react';
-import { QueryResponse, UseQueryResponse } from 'react-fetching-library';
-
-export type UsePaginatedQueryResponse<T> = UseQueryResponse<T> & {
-    count: number;
-};
+import { QueryResponse } from 'react-fetching-library';
 
 const transformPayload = <FROM, TO>(payload: FROM | undefined, status: number | undefined, adapter: (from: FROM) => TO): TO | undefined => {
     return status === 200 && payload ? adapter(payload) : undefined;
 };
 
-export const useTransformQueryResponse = <FROM, TO, USE_QUERY_RESPONSE_FROM extends UseQueryResponse<FROM> = UseQueryResponse<FROM>>(
+type ExpectedQueryResponse<FROM> = QueryResponse<FROM> & {
+    query: (action?: any) => Promise<QueryResponse<FROM>>;
+}
+
+export const useTransformQueryResponse = <FROM, TO, USE_QUERY_RESPONSE_FROM extends ExpectedQueryResponse<FROM>>(
     queryResponse: USE_QUERY_RESPONSE_FROM,
     adapter: (from: FROM) => TO
 ): Omit<USE_QUERY_RESPONSE_FROM, 'payload' | 'query'> & {
-    query: () => Promise<QueryResponse<TO>>;
+    query: (...args: Parameters<USE_QUERY_RESPONSE_FROM['query']>) => Promise<QueryResponse<TO>>;
     payload: undefined | TO;
 } => {
     const { payload, query, status } = queryResponse;
 
-    const transformedQuery = React.useCallback((): Promise<QueryResponse<TO>> => {
-        return query().then(response => ({
+    const transformedQuery = React.useCallback((...args: Parameters<USE_QUERY_RESPONSE_FROM['query']>): Promise<QueryResponse<TO>> => {
+        return query(...args).then(response => ({
             ...response,
             payload: transformPayload(response.payload, response.status, adapter)
         }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,6 +2626,14 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 bail@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.4.tgz#7181b66d508aa3055d3f6c13f0a0c720641dde9b"
@@ -3598,10 +3606,20 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
   integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
+core-js@^2.4.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
 core-js@^2.5.0:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
   integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
+
+core-js@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -5100,6 +5118,21 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-mock@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-9.4.0.tgz#9be073577bcfa57af714ca91f7536aff8450ec88"
+  integrity sha512-tqnFmcjYheW5Z9zOPRVY+ZXjB/QWCYtPiOrYGEsPgKfpGHco97eaaj7Rv9MjK7PVWG4rWfv6t2IgQAzDQizBZA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^3.0.0"
+    debug "^4.1.1"
+    glob-to-regexp "^0.4.0"
+    is-subset "^0.1.1"
+    lodash.isequal "^4.5.0"
+    path-to-regexp "^2.2.1"
+    querystring "^0.2.0"
+    whatwg-url "^6.5.0"
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -5565,6 +5598,11 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob-to-regexp@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
   version "7.1.5"
@@ -9003,6 +9041,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -9503,7 +9546,7 @@ querystring-es3@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
-querystring@0.2.0:
+querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
@@ -9898,6 +9941,11 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.2:
   version "0.13.3"
@@ -12369,7 +12417,7 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url@^6.4.1:
+whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==


### PR DESCRIPTION
This is to truly know at a given time if the user has more elements in case a filtered search yields 0 elements, to be able to show which empty state to show (you have no policies or no policies match the filter) and for knowing if we want to show the "copy from policy" option in the wizard.

- Also adding fetch-mock library (for mocking network requests)