### PR TITLE
  POL-190: updating style of description header in expanded table to …

### DIFF
--- a/src/components/Pf/PFVariables.tsx
+++ b/src/components/Pf/PFVariables.tsx
@@ -1,0 +1,11 @@
+
+// Form shared values https://www.patternfly.org/v4/documentation/core/components/form
+export enum PFVariables {
+    Form = 'pf-c-form',
+    FormControl = 'pf-c-form-control',
+    FormGroup = 'pf-c-form__group',
+    FormLabel = 'pf-c-form__label',
+    FormLabelText = 'pf-c-form__label-text',
+    FormLabelRequired = 'pf-c-form__label-required',
+    VerticalAlignLabels = 'vertical-align-labels-vertical-form-name'
+}

--- a/src/components/Pf/components/form/PfForm.tsx
+++ b/src/components/Pf/components/form/PfForm.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { PFVariables } from '../../PFVariables';
+import { hyphenate } from '../../../../utils/ComponentUtils';
+
+interface PfVAlignFormProps {
+    title: string;
+    indx: string;
+    showAsRequired?: boolean;
+    showInputField?: boolean;
+}
+
+export const VAlignForm: React.FunctionComponent<PfVAlignFormProps> = (props) => {
+    return (
+        <form noValidate className={ PFVariables.Form }>
+            <div className={ PFVariables.FormGroup }>
+                <label className={ PFVariables.FormLabel } htmlFor={ hyphenate(PFVariables.VerticalAlignLabels, props.indx) }>
+                    <span className={ PFVariables.FormLabelText }>{props.title}</span>
+                    { props.showAsRequired &&
+                       <span className={ PFVariables.FormLabelRequired } aria-hidden="true">&#42;</span> }
+                </label>
+                { props.showInputField && <input className={ PFVariables.FormControl } type="text"
+                    id={ hyphenate(PFVariables.VerticalAlignLabels, props.indx) } name={ hyphenate(PFVariables.VerticalAlignLabels,  props.indx) }
+                    required/>}
+            </div>
+        </form>
+    );
+};

--- a/src/components/Pf/components/form/PfForm.tsx
+++ b/src/components/Pf/components/form/PfForm.tsx
@@ -1,27 +1,30 @@
 import * as React from 'react';
-import { PFVariables } from '../../PFVariables';
 import { hyphenate } from '../../../../utils/ComponentUtils';
+import { Form, FormGroup } from '@patternfly/react-core';
 
-interface PfVAlignFormProps {
-    title: string;
-    indx: string;
+const formName = 'simple-form';//label name
+
+// Uses the following component to create i)Form labels with optional
+// ii)required iii)popover iv)HelpText, etc..
+export class VAlignForm extends React.Component<{
+    title?: string;
+    identification?: string;
     showAsRequired?: boolean;
-    showInputField?: boolean;
+    showPopover?: boolean;
+    popoverMessage?: string;
+    helpText?: string;
+    children?: React.ReactNode;
+}> {
+    render() {
+        return (
+            <Form>
+                { !this.props.showAsRequired && <FormGroup label={ this.props.title }
+                    fieldId={ hyphenate(formName, (this.props.identification ? this.props.identification : '')) }
+                />}
+                { this.props.showAsRequired && <FormGroup label={ this.props.title } isRequired
+                    fieldId={ hyphenate(formName, (this.props.identification ? this.props.identification : '')) }/>
+                }
+            </Form>
+        );
+    }
 }
-
-export const VAlignForm: React.FunctionComponent<PfVAlignFormProps> = (props) => {
-    return (
-        <form noValidate className={ PFVariables.Form }>
-            <div className={ PFVariables.FormGroup }>
-                <label className={ PFVariables.FormLabel } htmlFor={ hyphenate(PFVariables.VerticalAlignLabels, props.indx) }>
-                    <span className={ PFVariables.FormLabelText }>{props.title}</span>
-                    { props.showAsRequired &&
-                       <span className={ PFVariables.FormLabelRequired } aria-hidden="true">&#42;</span> }
-                </label>
-                { props.showInputField && <input className={ PFVariables.FormControl } type="text"
-                    id={ hyphenate(PFVariables.VerticalAlignLabels, props.indx) } name={ hyphenate(PFVariables.VerticalAlignLabels,  props.indx) }
-                    required/>}
-            </div>
-        </form>
-    );
-};

--- a/src/components/Pf/components/form/PfForm.tsx
+++ b/src/components/Pf/components/form/PfForm.tsx
@@ -1,28 +1,54 @@
 import * as React from 'react';
 import { hyphenate } from '../../../../utils/ComponentUtils';
-import { Form, FormGroup } from '@patternfly/react-core';
+import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 
-const formName = 'simple-form';//label name
-
-// Uses the following component to create i)Form labels with optional
-// ii)required iii)popover iv)HelpText, etc..
-export class VAlignForm extends React.Component<{
+interface VAlignFormProps {
     title?: string;
     identification?: string;
     showAsRequired?: boolean;
     showPopover?: boolean;
+    showHelpText?: boolean;
+    showInputField?: boolean;
+    showInputFieldAsRequired?: boolean;
     popoverMessage?: string;
     helpText?: string;
     children?: React.ReactNode;
-}> {
+}
+
+const formName = 'simple-form';//label name
+const formInputName = 'simple-form-input';//label name
+
+// Uses the following component to create i)Form labels with optional
+// ii)required iii)popover iv)HelpText, etc..
+export class VAlignForm extends React.Component< VAlignFormProps> {
+    constructor(props) {
+        super(props);
+    }
+    handleTextInputChange1() {
+        //override with implementation logic
+    };
+
     render() {
         return (
             <Form>
-                { !this.props.showAsRequired && <FormGroup label={ this.props.title }
+                { !this.props.showInputField && <FormGroup label={ this.props.title }
                     fieldId={ hyphenate(formName, (this.props.identification ? this.props.identification : '')) }
+                    helperText={ this.props.showHelpText && this.props.helpText } isRequired={ this.props.showAsRequired }
                 />}
-                { this.props.showAsRequired && <FormGroup label={ this.props.title } isRequired
-                    fieldId={ hyphenate(formName, (this.props.identification ? this.props.identification : '')) }/>
+                { this.props.showInputField &&
+                <FormGroup label={ this.props.title }
+                    fieldId={ hyphenate(formName, (this.props.identification ? this.props.identification : '')) }
+                    helperText={ this.props.showHelpText && this.props.helpText } isRequired={ this.props.showAsRequired }>
+                    <TextInput
+                        isRequired={ this.props.showInputFieldAsRequired }
+                        type="text"
+                        id={ hyphenate(formInputName, (this.props.identification ? this.props.identification : '')) }
+                        name={ hyphenate(formInputName, (this.props.identification ? this.props.identification : '')) }
+                        aria-describedby="simple-form-name-helper"
+                        value="(change me)"
+                        onChange={ this.handleTextInputChange1 }
+                    />
+                </FormGroup>
                 }
             </Form>
         );

--- a/src/components/Pf/components/form/PfForm.tsx
+++ b/src/components/Pf/components/form/PfForm.tsx
@@ -26,7 +26,7 @@ export class VAlignForm extends React.Component< VAlignFormProps> {
     }
     handleTextInputChange1() {
         //override with implementation logic
-    };
+    }
 
     render() {
         return (

--- a/src/components/Policy/Table/ExpandedContent/Description.tsx
+++ b/src/components/Policy/Table/ExpandedContent/Description.tsx
@@ -10,7 +10,7 @@ interface DescriptionProps {
 export const Description: React.FunctionComponent<DescriptionProps> = (props) => {
     return (
         <>
-            <VAlignForm title={ Messages.labels.description } indx="desc"/>
+            <VAlignForm title={ Messages.labels.description } />
             <Text> { props.description } </Text>
         </>
     );

--- a/src/components/Policy/Table/ExpandedContent/Description.tsx
+++ b/src/components/Policy/Table/ExpandedContent/Description.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { Text, Title, TitleSize } from '@patternfly/react-core';
+import { Text } from '@patternfly/react-core';
+import { VAlignForm } from '../../../Pf/components/form/PfForm';
+import { Messages } from '../../../../properties/Messages';
 
 interface DescriptionProps {
     description: string;
@@ -8,7 +10,7 @@ interface DescriptionProps {
 export const Description: React.FunctionComponent<DescriptionProps> = (props) => {
     return (
         <>
-            <Title size={ TitleSize.md }>Description</Title>
+            <VAlignForm title={ Messages.labels.description } indx="desc"/>
             <Text> { props.description } </Text>
         </>
     );

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -131,6 +131,9 @@ const MutableMessages = {
                 }
             }
         }
+    },
+    labels: {
+        description: 'Description'
     }
 };
 

--- a/src/utils/ComponentUtils.tsx
+++ b/src/utils/ComponentUtils.tsx
@@ -17,3 +17,5 @@ export const join: JoinType = (elements, GlueComponent) => {
 };
 
 export const joinClasses = (...args: string[]) => args.join(' ');
+
+export const hyphenate = (...args: string[]) => args.join('-');

--- a/src/utils/__tests__/ComponentUtils.test.tsx
+++ b/src/utils/__tests__/ComponentUtils.test.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { joinClasses, join } from '../ComponentUtils';
+import { joinClasses, join, hyphenate } from '../ComponentUtils';
 
 describe('src/utils/ComponentUtils', () => {
     it('joinClasses joins multiple classes into one string', () => {
         expect(joinClasses('a', 'b', 'c')).toEqual('a b c');
+    });
+
+    it('hyphenate joins multiple strings together', () => {
+        expect(hyphenate('a', 'b', 'c')).toEqual('a-b-c');
     });
 
     it ('join joins multiple elements using other component as divider', () => {


### PR DESCRIPTION
…use PF Css variables.

To use some of the requested PF components and sizing can also require some structural changes/additions.  
I'm proposing that we create classes that help extract and re-use some of the relevant css selectors into policy components where possible. Hopefully this approach can expose the requested PF size/behavior/color/spacing etc. without decreasing readability of the existing widgets and not introducing too many odd 'missing unique id' issues.

It feels like making more cookie-cutter patternfly widgets available without a full rewrite each time should be valuable almost everywhere.