### PR TITLE
POL-282 Follow up on details page

### DIFF
--- a/src/components/Trigger/Table.tsx
+++ b/src/components/Trigger/Table.tsx
@@ -15,6 +15,9 @@ import { Trigger } from '../../types/Trigger';
 import format from 'date-fns/format';
 import { Direction, Sort } from '../../types/Page';
 import { toUtc } from '../../utils/Date';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { localUrl } from '../../config/Config';
+import { TriggerTableEmptyState } from './Table/EmptyState';
 
 interface TriggerTableProps {
     rows?: Trigger[];
@@ -85,6 +88,12 @@ export const TriggerTable: React.FunctionComponent<TriggerTableProps> = (props) 
                 columns={ cells }
                 sortBy={ sortBy }
             />
+        );
+    }
+
+    if (rows.length === 0) {
+        return (
+            <TriggerTableEmptyState/>
         );
     }
 

--- a/src/components/Trigger/Table.tsx
+++ b/src/components/Trigger/Table.tsx
@@ -39,8 +39,7 @@ const cells: ICell[] = [
 
 const dateFormatString = 'dd MMM yyyy HH:mm:ss';
 
-// Todo: Uncomment next line once we have the correct id
-// const linkToHost = (id: string) => localUrl(`/insights/inventory/${id}/`);
+const linkToHost = (id: string) => localUrl(`/insights/inventory/${id}/`);
 
 export const TriggerTable: React.FunctionComponent<TriggerTableProps> = (props) => {
 
@@ -52,9 +51,11 @@ export const TriggerTable: React.FunctionComponent<TriggerTableProps> = (props) 
                 key: `${t.id}-${index}`,
                 cells: [
                     <>{ format(toUtc(t.created), dateFormatString) } UTC</>,
-                    // Todo: Looks like the id from the trigger does not point to the inventory element
-                    // <><Button component="a" variant={ ButtonVariant.link } href={ linkToHost(t.id) } >{ t.hostName }</Button></>
-                    <>{ t.hostName }</>
+                    t.id ? (
+                        <><Button component="a" variant={ ButtonVariant.link } href={ linkToHost(t.id) } >{ t.hostName }</Button></>
+                    ) : (
+                        <>{ t.hostName }</>
+                    )
                 ]
             }));
         }

--- a/src/components/Trigger/Table.tsx
+++ b/src/components/Trigger/Table.tsx
@@ -85,6 +85,7 @@ export const TriggerTable: React.FunctionComponent<TriggerTableProps> = (props) 
     if (props.loading) {
         return (
             <SkeletonTable
+                testID="trigger-table-loading"
                 rowSize={ 10 }
                 columns={ cells }
                 sortBy={ sortBy }

--- a/src/components/Trigger/Table.tsx
+++ b/src/components/Trigger/Table.tsx
@@ -52,7 +52,7 @@ export const TriggerTable: React.FunctionComponent<TriggerTableProps> = (props) 
                 cells: [
                     <>{ format(toUtc(t.created), dateFormatString) } UTC</>,
                     t.id ? (
-                        <><Button component="a" variant={ ButtonVariant.link } href={ linkToHost(t.id) } >{ t.hostName }</Button></>
+                        <><Button component="a" variant={ ButtonVariant.link } href={ linkToHost(t.id) } isInline>{ t.hostName }</Button></>
                     ) : (
                         <>{ t.hostName }</>
                     )

--- a/src/components/Trigger/Table/EmptyState.tsx
+++ b/src/components/Trigger/Table/EmptyState.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { CubesIcon } from '@patternfly/react-icons';
 import { EmptyStateSection } from '../../Policy/EmptyState/Section';
 import { Messages } from '../../../properties/Messages';
 
 export const TriggerTableEmptyState: React.FunctionComponent = () => {
     return <EmptyStateSection
-        icon={ CubesIcon }
         title={ Messages.tables.trigger.emptyState.notFound.title }
         content={ Messages.tables.trigger.emptyState.notFound.content }
     />;

--- a/src/components/Trigger/Table/EmptyState.tsx
+++ b/src/components/Trigger/Table/EmptyState.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { CubesIcon } from '@patternfly/react-icons';
+import { EmptyStateSection } from '../../Policy/EmptyState/Section';
+import { Messages } from '../../../properties/Messages';
+
+export const TriggerTableEmptyState: React.FunctionComponent = () => {
+    return <EmptyStateSection
+        icon={ CubesIcon }
+        title={ Messages.tables.trigger.emptyState.notFound.title }
+        content={ Messages.tables.trigger.emptyState.notFound.content }
+    />;
+};

--- a/src/components/Trigger/TableToolbar.tsx
+++ b/src/components/Trigger/TableToolbar.tsx
@@ -118,7 +118,8 @@ export const TriggerTableToolbar: React.FunctionComponent<TriggerTableToolbarPro
             extraItems: [],
             onSelect: (_event, type: string) => {
                 onExport(exporterTypeFromString(type));
-            }
+            },
+            'data-testid': 'trigger-toolbar-export-container'
         };
     }, [ props.onExport ]);
 

--- a/src/components/Trigger/__tests__/Table.test.tsx
+++ b/src/components/Trigger/__tests__/Table.test.tsx
@@ -10,6 +10,11 @@ describe('src/components/Trigger/Table', () => {
         expect(screen.getByText('No matching triggers found')).toBeVisible();
     });
 
+    it('renders loading when loading is true', () => {
+        render(<TriggerTable loading={ true }/>);
+        expect(screen.getByRole('grid')).toHaveAttribute('aria-label', 'Loading');
+    });
+
     it('renders triggers passed', () => {
         render(<TriggerTable
             rows={ [
@@ -27,6 +32,27 @@ describe('src/components/Trigger/Table', () => {
         />);
         expect(screen.getByText('my-hostname-foo')).toBeTruthy();
         expect(screen.getByText('my-hostname-bar')).toBeTruthy();
+        expect(screen.getByText('28 May 2020 21:20:36 UTC')).toBeTruthy();
+        expect(screen.getByText('27 May 2020 19:16:30 UTC')).toBeTruthy();
+    });
+
+    it('Hostname creates a link to the inventory', () => {
+        render(<TriggerTable
+            rows={ [
+                {
+                    id: 'foo-id',
+                    hostName: 'my-hostname-foo',
+                    created: new Date(1590700836387)
+                },
+                {
+                    id: 'meep',
+                    hostName: 'my-hostname-bar',
+                    created: new Date(1590606990814)
+                }
+            ] }
+        />);
+        expect(screen.getByText('my-hostname-foo').closest('a')).toHaveAttribute('href', '/beta/insights/inventory/foo-id/');
+        expect(screen.getByText('my-hostname-bar').closest('a')).toHaveAttribute('href', '/beta/insights/inventory/meep/');
         expect(screen.getByText('28 May 2020 21:20:36 UTC')).toBeTruthy();
         expect(screen.getByText('27 May 2020 19:16:30 UTC')).toBeTruthy();
     });

--- a/src/components/Trigger/__tests__/Table.test.tsx
+++ b/src/components/Trigger/__tests__/Table.test.tsx
@@ -5,10 +5,9 @@ import { TriggerTable } from '../Table';
 import { Direction, Sort } from '../../../types/Page';
 
 describe('src/components/Trigger/Table', () => {
-    it('renders empty table with no props', () => {
+    it('renders empty state when no rows', () => {
         render(<TriggerTable/>);
-        expect(screen.getByText('Date')).toBeVisible();
-        expect(screen.getByText('System')).toBeVisible();
+        expect(screen.getByText('No matching triggers found')).toBeVisible();
     });
 
     it('renders triggers passed', () => {

--- a/src/components/Trigger/__tests__/TableToolbar.test.tsx
+++ b/src/components/Trigger/__tests__/TableToolbar.test.tsx
@@ -229,7 +229,8 @@ describe('src/components/Trigger/TableToolbar', () => {
 
         expect(control.props.exportConfig).toEqual({
             extraItems: [ ],
-            onSelect: onSelectMockFn
+            onSelect: onSelectMockFn,
+            'data-testid': 'trigger-toolbar-export-container'
         });
 
         onSelectOriginal(undefined, 'json');

--- a/src/components/Trigger/__tests__/TableToolbar.test.tsx
+++ b/src/components/Trigger/__tests__/TableToolbar.test.tsx
@@ -1,0 +1,238 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
+import { TriggerTableToolbar } from '../TableToolbar';
+import { Page } from '../../../types/Page';
+import { TriggerFilterColumn } from '../../../pages/PolicyDetail/hooks/useTriggerFilter';
+import { PaginationVariant } from '@patternfly/react-core';
+import { ExporterType } from '../../../utils/exporters/Type';
+
+jest.mock('@redhat-cloud-services/frontend-components');
+
+describe('src/components/Trigger/TableToolbar', () => {
+
+    const mockPrimaryToolbar = () => {
+        const mockedControl = {
+            props: undefined
+        };
+        (PrimaryToolbar as jest.Mock).mockImplementation(props => {
+            mockedControl.props = props;
+        });
+
+        return mockedControl as any;
+    };
+
+    beforeEach(() => {
+        (PrimaryToolbar as jest.Mock).mockReset();
+    });
+
+    const filterMocks = ({ system } = { system: '' }) => ({
+        [TriggerFilterColumn.SYSTEM]: system || ''
+    });
+
+    const setFilterMocks = () => ({
+        [TriggerFilterColumn.SYSTEM]: jest.fn()
+    });
+
+    it('Passes pagination props to the PrimaryToolbar', () => {
+        const control = mockPrimaryToolbar();
+        const paginationChanged = jest.fn();
+        render(<TriggerTableToolbar
+            page={ Page.of(33, 10) }
+            filters={ filterMocks() }
+            setFilters={ setFilterMocks() }
+            clearFilters={ jest.fn() }
+            onExport={ jest.fn() }
+            count={ 1337 }
+            onPaginationChanged={ paginationChanged }
+            pageCount={ 1 }
+        />);
+
+        expect(control.props.pagination).toEqual({
+            itemCount: 1337,
+            page: 33,
+            perPage: 10,
+            perPageOptions: [],
+            onSetPage: paginationChanged,
+            onFirstClick: paginationChanged,
+            onPreviousClick: paginationChanged,
+            onNextClick: paginationChanged,
+            onLastClick: paginationChanged,
+            onPageInput: paginationChanged,
+            isCompact: true,
+            variant: PaginationVariant.right
+        });
+    });
+
+    it('Passes filterConfig props to the PrimaryToolbar', () => {
+        const control = mockPrimaryToolbar();
+        const paginationChanged = jest.fn();
+        const setFilterMocksValues = setFilterMocks();
+
+        render(<TriggerTableToolbar
+            page={ Page.of(33, 10) }
+            filters={ filterMocks({
+                system: 'foo-bar'
+            }) }
+            setFilters={ setFilterMocksValues }
+            clearFilters={ jest.fn() }
+            onExport={ jest.fn() }
+            count={ 1337 }
+            onPaginationChanged={ paginationChanged }
+            pageCount={ 1 }
+        />);
+
+        const onChangeMockFn = jest.fn();
+        const onChangeOriginal = control.props.filterConfig.items[0].filterValues.onChange;
+        control.props.filterConfig.items[0].filterValues.onChange = onChangeMockFn;
+
+        expect(control.props.filterConfig).toEqual({
+            items: [
+                {
+                    label: 'System',
+                    type: 'text',
+                    filterValues: {
+                        id: 'filter-system',
+                        value: 'foo-bar',
+                        placeholder: 'Filter by system',
+                        onChange: onChangeMockFn
+                    }
+                }
+            ]
+        });
+
+        onChangeOriginal(undefined, 'my value');
+        expect(setFilterMocksValues[TriggerFilterColumn.SYSTEM]).toHaveBeenCalledWith('my value');
+    });
+
+    it('Passes activeFiltersConfig props to the PrimaryToolbar with filter', () => {
+        const control = mockPrimaryToolbar();
+        const paginationChanged = jest.fn();
+        const setFilterMocksValues = setFilterMocks();
+        const clearFn = jest.fn();
+
+        render(<TriggerTableToolbar
+            page={ Page.of(33, 10) }
+            filters={ filterMocks({
+                system: 'foo-bar'
+            }) }
+            setFilters={ setFilterMocksValues }
+            clearFilters={ clearFn }
+            onExport={ jest.fn() }
+            count={ 1337 }
+            onPaginationChanged={ paginationChanged }
+            pageCount={ 1 }
+        />);
+
+        const onDeleteMockFn = jest.fn();
+        const onDeleteOriginal = control.props.activeFiltersConfig.onDelete;
+        control.props.activeFiltersConfig.onDelete = onDeleteMockFn;
+
+        expect(control.props.activeFiltersConfig).toEqual({
+            filters: [
+                {
+                    category: 'System',
+                    chips: [
+                        {
+                            name: 'foo-bar',
+                            isRead: true
+                        }
+                    ]
+                }
+            ],
+            onDelete: onDeleteMockFn
+        });
+
+        onDeleteOriginal(undefined, [
+            {
+                category: 'System'
+            }
+        ]);
+        expect(clearFn).toHaveBeenCalledWith([ TriggerFilterColumn.SYSTEM ]);
+    });
+
+    it('activeFiltersConfig.onDelete throws with a invalid filter', () => {
+        const control = mockPrimaryToolbar();
+        const paginationChanged = jest.fn();
+        const setFilterMocksValues = setFilterMocks();
+        const clearFn = jest.fn();
+
+        render(<TriggerTableToolbar
+            page={ Page.of(33, 10) }
+            filters={ filterMocks({
+                system: 'foo-bar'
+            }) }
+            setFilters={ setFilterMocksValues }
+            clearFilters={ clearFn }
+            onExport={ jest.fn() }
+            count={ 1337 }
+            onPaginationChanged={ paginationChanged }
+            pageCount={ 1 }
+        />);
+
+        const onDeleteOriginal = control.props.activeFiltersConfig.onDelete;
+
+        expect(() => {
+            onDeleteOriginal(undefined, [
+                {
+                    category: 'Wrong'
+                }
+            ]);
+        }).toThrowError(/Unknown filter found/i)
+        expect(clearFn).not.toHaveBeenCalled();
+    });
+
+    it('Passes activeFiltersConfig props to the PrimaryToolbar with no filter', () => {
+        const control = mockPrimaryToolbar();
+        const paginationChanged = jest.fn();
+        const setFilterMocksValues = setFilterMocks();
+        const clearFn = jest.fn();
+
+        render(<TriggerTableToolbar
+            page={ Page.of(33, 10) }
+            filters={ filterMocks() }
+            setFilters={ setFilterMocksValues }
+            clearFilters={ clearFn }
+            onExport={ jest.fn() }
+            count={ 1337 }
+            onPaginationChanged={ paginationChanged }
+            pageCount={ 1 }
+        />);
+
+        const onDeleteMockFn = jest.fn();
+        control.props.activeFiltersConfig.onDelete = onDeleteMockFn;
+
+        expect(control.props.activeFiltersConfig).toEqual({
+            filters: [ ],
+            onDelete: onDeleteMockFn
+        });
+    });
+
+    it('Passes exportConfig props to the PrimaryToolbar', () => {
+        const control = mockPrimaryToolbar();
+        const onExport = jest.fn();
+
+        render(<TriggerTableToolbar
+            page={ Page.of(33, 10) }
+            filters={ filterMocks() }
+            setFilters={ setFilterMocks() }
+            clearFilters={ jest.fn() }
+            onExport={ onExport }
+            count={ 1337 }
+            onPaginationChanged={ jest.fn() }
+            pageCount={ 1 }
+        />);
+
+        const onSelectMockFn = jest.fn();
+        const onSelectOriginal = control.props.exportConfig.onSelect;
+        control.props.exportConfig.onSelect = onSelectMockFn;
+
+        expect(control.props.exportConfig).toEqual({
+            extraItems: [ ],
+            onSelect: onSelectMockFn
+        });
+
+        onSelectOriginal(undefined, 'json');
+        expect(onExport).toHaveBeenCalledWith(ExporterType.JSON);
+    });
+});

--- a/src/components/Trigger/__tests__/TableToolbar.test.tsx
+++ b/src/components/Trigger/__tests__/TableToolbar.test.tsx
@@ -178,7 +178,7 @@ describe('src/components/Trigger/TableToolbar', () => {
                     category: 'Wrong'
                 }
             ]);
-        }).toThrowError(/Unknown filter found/i)
+        }).toThrowError(/Unknown filter found/i);
         expect(clearFn).not.toHaveBeenCalled();
     });
 

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -6,9 +6,9 @@ export interface UsePolicySortReturn {
     onSort: OnSortHandlerType;
 }
 
-export const useSort = (): UsePolicySortReturn => {
+export const useSort = (defaultSort?: Sort): UsePolicySortReturn => {
 
-    const [ sortBy, setSortBy ] = React.useState<Sort>();
+    const [ sortBy, setSortBy ] = React.useState<Sort | undefined>(defaultSort);
 
     const onSort = React.useCallback<OnSortHandlerType>((index: number, column: string, direction: Direction) => {
         setSortBy(Sort.by(column, direction));

--- a/src/pages/CreatePolicyWizard/CreatePolicyWizard.tsx
+++ b/src/pages/CreatePolicyWizard/CreatePolicyWizard.tsx
@@ -10,7 +10,7 @@ import { useValidatePolicyNameParametrizedQuery } from '../../services/useValida
 import { useFacts } from '../../hooks/useFacts';
 
 type CreatePolicyWizardBase = {
-    close: (policyCreated: boolean) => void;
+    close: (policy: Policy | undefined) => void;
     initialValue?: NewPolicy;
     showCreateStep: boolean;
     policiesExist?: boolean;
@@ -52,7 +52,7 @@ export const CreatePolicyWizard: React.FunctionComponent<CreatePolicyWizardProps
                         addSuccessNotification('Saved', `Policy "${policy.name}" has been updated`);
                     }
 
-                    props.close && props.close(true);
+                    props.close && props.close(res.payload);
                     return {
                         created: true
                     };
@@ -68,7 +68,7 @@ export const CreatePolicyWizard: React.FunctionComponent<CreatePolicyWizardProps
                 default:
                     return {
                         created: false,
-                        error: res.payload?.msg || `Unknown Error when trying to ${
+                        error: (res.payload as any)?.msg || `Unknown Error when trying to ${
                             policy.id === undefined ? 'create' : 'update'
                         } the policy: (Code ${res.status})`
                     };
@@ -118,7 +118,7 @@ export const CreatePolicyWizard: React.FunctionComponent<CreatePolicyWizardProps
             { props.isOpen &&
             <PolicyWizard
                 initialValue={ props.initialValue || { } }
-                onClose={ () => { props.close(false); } }
+                onClose={ () => { props.close(undefined); } }
                 onSave={ onSave }
                 onVerify={ onVerify }
                 onValidateName={ onValidateName }

--- a/src/pages/CreatePolicyWizard/__tests__/CreatePolicyWizard.test.tsx
+++ b/src/pages/CreatePolicyWizard/__tests__/CreatePolicyWizard.test.tsx
@@ -194,7 +194,7 @@ describe('src/pages/ListPage/CreatePolicyWizard', () => {
             });
         });
 
-        it('Calls props.close with true when the policy is created / saved', async () => {
+        it('Calls props.close with the policy when the policy is created / saved', async () => {
             const trigger = jest.fn();
             configurePolicyWizard(props => {
                 trigger.mockImplementation(props.onSave);
@@ -204,7 +204,15 @@ describe('src/pages/ListPage/CreatePolicyWizard', () => {
                 '/api/policies/v1.0/policies?alsoStore=true',
                 {
                     headers: {},
-                    status: 201
+                    status: 201,
+                    body: {
+                        id: '1234',
+                        name: 'foo',
+                        mtime: 1,
+                        ctime: 1,
+                        isEnabled: false,
+                        description: ''
+                    }
                 }
             );
 
@@ -221,7 +229,16 @@ describe('src/pages/ListPage/CreatePolicyWizard', () => {
                 expect(result.created).toBe(true);
             });
 
-            expect(closeFn).toHaveBeenCalledWith(true);
+            expect(closeFn).toHaveBeenCalledWith({
+                id: '1234',
+                name: 'foo',
+                actions: [],
+                isEnabled: false,
+                lastTriggered: undefined,
+                description: '',
+                ctime: new Date('1970-01-01T00:00:00.001Z'),
+                mtime: new Date('1970-01-01T00:00:00.001Z')
+            });
         });
 
         it('Adds a success notification when a policy is created', async () => {

--- a/src/pages/ListPage/DeletePolicy.tsx
+++ b/src/pages/ListPage/DeletePolicy.tsx
@@ -6,8 +6,8 @@ import { Policy, Uuid } from '../../types/Policy/Policy';
 import { useMassDeletePoliciesMutation } from '../../services/useMassDeletePolicies';
 
 export interface DeletePolicyProps {
-    getPolicies: () => Promise<Uuid[]>;
-    onDeleted: (policyId: Uuid) => void;
+    getPolicies?: () => Promise<Uuid[]>;
+    onDeleted?: (policyId: Uuid) => void;
     onClose: (deleted: boolean) => void;
     loading: boolean;
     count: number;
@@ -32,7 +32,7 @@ export const DeletePolicy: React.FunctionComponent<DeletePolicyProps> = (props) 
 
             if (errorCount === 0) {
                 errorCount =  policyIds.filter(id => response.payload && !response.payload.includes(id)).length;
-                response.payload?.forEach(id => onDeleted(id));
+                response.payload?.forEach(id => onDeleted && onDeleted(id));
             }
 
             if (errorCount > 0) {
@@ -52,7 +52,7 @@ export const DeletePolicy: React.FunctionComponent<DeletePolicyProps> = (props) 
     const deletePolicy = React.useCallback(async () => {
         if (policy) {
             deletePoliciesWithIds([ policy.id ]);
-        } else {
+        } else if (getPolicies) {
             try {
                 const policyIds = await getPolicies();
                 deletePoliciesWithIds(policyIds);
@@ -63,6 +63,8 @@ export const DeletePolicy: React.FunctionComponent<DeletePolicyProps> = (props) 
                 );
                 console.error('Error while fetching selection', error);
             }
+        } else {
+            throw new Error('Expected policy or getPolicies to bet set');
         }
     }, [ getPolicies, deletePoliciesWithIds, policy ]);
 

--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -205,9 +205,9 @@ const ListPage: React.FunctionComponent<ListPageProps> = (_props) => {
         });
     }, [ setPolicyWizardState ]);
 
-    const closePolicyWizard = React.useCallback((policyCreated: boolean) => {
+    const closePolicyWizard = React.useCallback((policy: NewPolicy | undefined) => {
         const refreshUserSettings = appContext.userSettings.refresh;
-        if (policyCreated) {
+        if (policy) {
             getPoliciesQueryReload();
             refreshUserSettings();
         }

--- a/src/pages/PolicyDetail/Actions.tsx
+++ b/src/pages/PolicyDetail/Actions.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternfly/react-core';
+
+interface ActionsProps {
+    edit: () => void;
+    duplicate: () => void;
+    changeEnabled: (isEnabled: boolean) => void;
+    disabled: boolean;
+    isEnabled: boolean;
+    loadingEnabledChange: boolean;
+}
+
+export const PolicyDetailActions: React.FunctionComponent<ActionsProps> = (props) => {
+
+    const [ isOpen, setOpen ] = React.useState(false);
+
+    const onSelect = React.useCallback(() => {
+        setOpen(false);
+    }, []);
+
+    const items = React.useMemo(() => {
+        const changeEnabled = props.changeEnabled;
+        const localItems: Array<React.ReactNode> = [];
+        if (props.isEnabled) {
+            localItems.push(
+                <DropdownItem
+                    isDisabled={ props.loadingEnabledChange }
+                    onClick={ () => changeEnabled(false) }
+                    key="disable"
+                >
+                    Disable
+                </DropdownItem>);
+        } else {
+            localItems.push(
+                <DropdownItem
+                    isDisabled={ props.loadingEnabledChange }
+                    onClick={ () => changeEnabled(true) }
+                    key="enable"
+                >
+                    Enable
+                </DropdownItem>);
+        }
+
+        localItems.push(
+            <DropdownItem key="edit" onClick={ props.edit }>Edit</DropdownItem>,
+            <DropdownItem key="duplicate" onClick={ props.duplicate }>Duplicate</DropdownItem>,
+            <DropdownItem key="delete">Delete</DropdownItem>
+        );
+
+        return localItems;
+    }, [ props.isEnabled, props.changeEnabled, props.edit, props.duplicate, props.loadingEnabledChange ]);
+
+    return (
+        <Dropdown
+            position={ DropdownPosition.right }
+            onSelect={ onSelect }
+            toggle={ <KebabToggle isDisabled={ props.disabled } onToggle={ setOpen } id="policy-detail-actions-menu"  /> }
+            isOpen={ isOpen }
+            isPlain
+            dropdownItems={ items }
+        />
+    );
+};

--- a/src/pages/PolicyDetail/Actions.tsx
+++ b/src/pages/PolicyDetail/Actions.tsx
@@ -55,7 +55,7 @@ export const PolicyDetailActions: React.FunctionComponent<ActionsProps> = (props
         <Dropdown
             position={ DropdownPosition.right }
             onSelect={ onSelect }
-            toggle={ <KebabToggle isDisabled={ props.disabled } onToggle={ setOpen } id="policy-detail-actions-menu"  /> }
+            toggle={ <KebabToggle isDisabled={ props.disabled } onToggle={ setOpen } id="policy-detail-actions-menu"/> }
             isOpen={ isOpen }
             isPlain
             dropdownItems={ items }

--- a/src/pages/PolicyDetail/Actions.tsx
+++ b/src/pages/PolicyDetail/Actions.tsx
@@ -4,6 +4,7 @@ import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternf
 interface ActionsProps {
     edit: () => void;
     duplicate: () => void;
+    delete: () => void;
     changeEnabled: (isEnabled: boolean) => void;
     disabled: boolean;
     isEnabled: boolean;
@@ -44,7 +45,7 @@ export const PolicyDetailActions: React.FunctionComponent<ActionsProps> = (props
         localItems.push(
             <DropdownItem key="edit" onClick={ props.edit }>Edit</DropdownItem>,
             <DropdownItem key="duplicate" onClick={ props.duplicate }>Duplicate</DropdownItem>,
-            <DropdownItem key="delete">Delete</DropdownItem>
+            <DropdownItem key="delete" onClick={ props.delete }>Delete</DropdownItem>
         );
 
         return localItems;

--- a/src/pages/PolicyDetail/Actions.tsx
+++ b/src/pages/PolicyDetail/Actions.tsx
@@ -55,7 +55,11 @@ export const PolicyDetailActions: React.FunctionComponent<ActionsProps> = (props
         <Dropdown
             position={ DropdownPosition.right }
             onSelect={ onSelect }
-            toggle={ <KebabToggle isDisabled={ props.disabled } onToggle={ setOpen } id="policy-detail-actions-menu"/> }
+            toggle={ <KebabToggle
+                data-testid="policy-detail-actions-button"
+                isDisabled={ props.disabled }
+                onToggle={ setOpen }
+                id="policy-detail-actions-menu"/> }
             isOpen={ isOpen }
             isPlain
             dropdownItems={ items }

--- a/src/pages/PolicyDetail/Actions.tsx
+++ b/src/pages/PolicyDetail/Actions.tsx
@@ -49,7 +49,7 @@ export const PolicyDetailActions: React.FunctionComponent<ActionsProps> = (props
         );
 
         return localItems;
-    }, [ props.isEnabled, props.changeEnabled, props.edit, props.duplicate, props.loadingEnabledChange ]);
+    }, [ props.isEnabled, props.changeEnabled, props.edit, props.duplicate, props.delete, props.loadingEnabledChange ]);
 
     return (
         <Dropdown

--- a/src/pages/PolicyDetail/IsEnabled.tsx
+++ b/src/pages/PolicyDetail/IsEnabled.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import { Button, ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
+import { Stack, StackItem } from '@patternfly/react-core';
 import { style } from 'typestyle';
 
 import { Skeleton } from '@redhat-cloud-services/frontend-components';
 
 import { DisabledPolicyIcon, EnabledPolicyIcon } from '../../components/Icons';
 import { Spacer } from '../../utils/Spacer';
-import { Uuid } from '../../types/Policy/Policy';
-import { useMassChangePolicyEnabledMutation } from '../../services/useMassChangePolicyEnabled';
 
 const isEnabledTextClassname = style({
     marginLeft: Spacer.MD
@@ -18,33 +16,13 @@ const loadingClassname = style({
 });
 
 interface PolicyDetailIsEnabledProps {
-    policyId: Uuid;
     isEnabled: boolean;
-    statusChanged: (newStatus: boolean) => void;
+    loading: boolean;
 }
 
 export const PolicyDetailIsEnabled: React.FunctionComponent<PolicyDetailIsEnabledProps> = (props) => {
 
-    const changePolicyEnabled = useMassChangePolicyEnabledMutation();
-
-    const onChangeStatus = React.useCallback(newStatus => {
-        const mutate = changePolicyEnabled.mutate;
-        const statusChanged = props.statusChanged;
-        mutate({
-            policyIds: [ props.policyId ],
-            shouldBeEnabled: newStatus
-        }).then(() => statusChanged(newStatus));
-    }, [ props.policyId, changePolicyEnabled.mutate, props.statusChanged ]);
-
-    const enablePolicy = React.useCallback(() => {
-        onChangeStatus(true);
-    },  [ onChangeStatus ]);
-
-    const disablePolicy = React.useCallback(() => {
-        onChangeStatus(false);
-    },  [ onChangeStatus ]);
-
-    if (changePolicyEnabled.loading) {
+    if (props.loading) {
         return (
             <Stack data-testid="loading" className={ loadingClassname }>
                 <StackItem>
@@ -54,14 +32,12 @@ export const PolicyDetailIsEnabled: React.FunctionComponent<PolicyDetailIsEnable
         );
     }
 
-    const { icon, text, switchLink } = props.isEnabled ? {
+    const { icon, text } = props.isEnabled ? {
         icon: <EnabledPolicyIcon/>,
-        text: 'Enabled',
-        switchLink: <Button isInline onClick={ disablePolicy } variant={ ButtonVariant.link }> Disable policy </Button>
+        text: 'Enabled'
     } : {
         icon: <DisabledPolicyIcon/>,
-        text: 'Disabled',
-        switchLink: <Button isInline onClick={ enablePolicy } variant={ ButtonVariant.link }> Enable policy </Button>
+        text: 'Disabled'
     };
 
     return (
@@ -69,9 +45,6 @@ export const PolicyDetailIsEnabled: React.FunctionComponent<PolicyDetailIsEnable
             <StackItem>
                 { icon }
                 <span className={ isEnabledTextClassname }>{ text }</span>
-            </StackItem>
-            <StackItem>
-                { switchLink }
             </StackItem>
         </Stack>
     );

--- a/src/pages/PolicyDetail/IsEnabled.tsx
+++ b/src/pages/PolicyDetail/IsEnabled.tsx
@@ -14,7 +14,7 @@ const isEnabledTextClassname = style({
 });
 
 const loadingClassname = style({
-    minHeight: 60
+    minHeight: 48
 });
 
 interface PolicyDetailIsEnabledProps {
@@ -57,11 +57,11 @@ export const PolicyDetailIsEnabled: React.FunctionComponent<PolicyDetailIsEnable
     const { icon, text, switchLink } = props.isEnabled ? {
         icon: <EnabledPolicyIcon/>,
         text: 'Enabled',
-        switchLink: <Button onClick={ disablePolicy } variant={ ButtonVariant.link }> Disable policy </Button>
+        switchLink: <Button isInline onClick={ disablePolicy } variant={ ButtonVariant.link }> Disable policy </Button>
     } : {
         icon: <DisabledPolicyIcon/>,
         text: 'Disabled',
-        switchLink: <Button onClick={ enablePolicy } variant={ ButtonVariant.link }> Enable policy </Button>
+        switchLink: <Button isInline onClick={ enablePolicy } variant={ ButtonVariant.link }> Enable policy </Button>
     };
 
     return (

--- a/src/pages/PolicyDetail/PolicyDetail.tsx
+++ b/src/pages/PolicyDetail/PolicyDetail.tsx
@@ -44,6 +44,7 @@ import { makeCopyOfPolicy } from '../../types/adapters/PolicyAdapter';
 import { NewPolicy } from '../../types/Policy/Policy';
 import { usePolicyToDelete } from '../../hooks/usePolicyToDelete';
 import { DeletePolicy } from '../ListPage/DeletePolicy';
+import { Direction, Sort } from '../../types/Page';
 
 const recentTriggerVersionTitleClassname = style({
     paddingBottom: 8,
@@ -68,6 +69,8 @@ const closeState: PolicyDetailWizardState = {
     isOpen: false
 };
 
+const defaultSort = Sort.by('date', Direction.DESCENDING);
+
 export const PolicyDetail: React.FunctionComponent = () => {
 
     const { policyId: policyIdFromUrl } = useParams<{
@@ -88,7 +91,7 @@ export const PolicyDetail: React.FunctionComponent = () => {
     const triggerFilter = useTriggerFilter();
     const changePolicyEnabled = useMassChangePolicyEnabledMutation();
 
-    const sort = useSort();
+    const sort = useSort(defaultSort);
     const {
         page,
         onPaginationChanged

--- a/src/pages/PolicyDetail/PolicyDetail.tsx
+++ b/src/pages/PolicyDetail/PolicyDetail.tsx
@@ -42,6 +42,8 @@ import { useMassChangePolicyEnabledMutation } from '../../services/useMassChange
 import { assertNever } from '../../utils/Assert';
 import { makeCopyOfPolicy } from '../../types/adapters/PolicyAdapter';
 import { NewPolicy } from '../../types/Policy/Policy';
+import { usePolicyToDelete } from '../../hooks/usePolicyToDelete';
+import { DeletePolicy } from '../ListPage/DeletePolicy';
 
 const recentTriggerVersionTitleClassname = style({
     paddingBottom: 8,
@@ -78,6 +80,8 @@ export const PolicyDetail: React.FunctionComponent = () => {
 
     const appContext = useContext(AppContext);
     const { canWriteAll, canReadAll } = appContext.rbac;
+
+    const policyToDelete = usePolicyToDelete();
 
     const getPolicyQuery = useGetPolicyParametrizedQuery();
     const getTriggers = useGetPolicyTriggersParametrizedQuery();
@@ -152,6 +156,19 @@ export const PolicyDetail: React.FunctionComponent = () => {
     const duplicatePolicy = React.useCallback(() => {
         policyWizardDispatch(PolicyDetailWizardAction.DUPLICATE);
     }, [ policyWizardDispatch ]);
+
+    const deletePolicy = React.useCallback(() => {
+        const open = policyToDelete.open;
+        if (policy) {
+            open(policy);
+        }
+    }, [ policy, policyToDelete.open ]);
+
+    const onCloseDeletePolicy = React.useCallback((deleted: boolean) => {
+        if (deleted) {
+            history.push(linkTo.listPage());
+        }
+    }, [ history ]);
 
     const statusChanged = React.useCallback((newStatus: boolean) => {
         setPolicy(oldState => {
@@ -233,6 +250,7 @@ export const PolicyDetail: React.FunctionComponent = () => {
                                     disabled={ !canWriteAll }
                                     edit={ editPolicy }
                                     duplicate={ duplicatePolicy }
+                                    delete={ deletePolicy }
                                     changeEnabled={ onChangeStatus }
                                     loadingEnabledChange={ changePolicyEnabled.loading }
                                 />
@@ -290,6 +308,12 @@ export const PolicyDetail: React.FunctionComponent = () => {
                 policiesExist={ false }
                 initialValue={ policyWizardState.initialValue }
                 isEditing={ policyWizardState.isEditing }
+            /> }
+            { policyToDelete.isOpen && <DeletePolicy
+                onClose={ onCloseDeletePolicy }
+                loading={ false }
+                count={ policyToDelete.count }
+                policy={ policyToDelete.policy }
             /> }
         </>
     );

--- a/src/pages/PolicyDetail/PolicyDetail.tsx
+++ b/src/pages/PolicyDetail/PolicyDetail.tsx
@@ -38,6 +38,7 @@ import { useTriggerFilter } from './hooks/useTriggerFilter';
 import { ExporterType, exporterTypeFromString } from '../../utils/exporters/Type';
 import { format } from 'date-fns';
 import { triggerExporterFactory } from '../../utils/exporters/Trigger/Factory';
+import { PolicyDetailTriggerEmptyState } from './TriggerEmptyState';
 
 const recentTriggerVersionTitleClassname = style({
     paddingBottom: 8,
@@ -62,7 +63,7 @@ export const PolicyDetail: React.FunctionComponent = () => {
         onPaginationChanged
     } = useTriggerPage(sort.sortBy, triggerFilter.debouncedFilters);
 
-    const { count, pagedTriggers, processedTriggers } = usePagedTriggers(getTriggers.payload, page);
+    const { count, pagedTriggers, processedTriggers, rawCount } = usePagedTriggers(getTriggers.payload, page);
 
     const [ isEditing, setEditing ] = React.useState(false);
     const [ policy, setPolicy ] = React.useState<Policy>();
@@ -186,22 +187,28 @@ export const PolicyDetail: React.FunctionComponent = () => {
                     <Title size="lg">Recent trigger history</Title>
                 </div>
                 <Section>
-                    <TriggerTableToolbar
-                        count={ count }
-                        page={ page }
-                        onPaginationChanged={ onPaginationChanged }
-                        pageCount={ pagedTriggers.length }
-                        filters={ triggerFilter.filters }
-                        setFilters={ triggerFilter.setFilters }
-                        clearFilters={ triggerFilter.clearFilter }
-                        onExport={ onExport }
-                    />
-                    <TriggerTable
-                        rows={ pagedTriggers }
-                        onSort={ sort.onSort }
-                        sortBy={ sort.sortBy }
-                        loading={ getTriggers.loading }
-                    />
+                    { rawCount > 0 ? (
+                        <>
+                            <TriggerTableToolbar
+                                count={ count }
+                                page={ page }
+                                onPaginationChanged={ onPaginationChanged }
+                                pageCount={ pagedTriggers.length }
+                                filters={ triggerFilter.filters }
+                                setFilters={ triggerFilter.setFilters }
+                                clearFilters={ triggerFilter.clearFilter }
+                                onExport={ onExport }
+                            />
+                            <TriggerTable
+                                rows={ pagedTriggers }
+                                onSort={ sort.onSort }
+                                sortBy={ sort.sortBy }
+                                loading={ getTriggers.loading }
+                            />
+                        </>
+                    ) : (
+                        <PolicyDetailTriggerEmptyState/>
+                    ) }
                 </Section>
             </Main>
             { isEditing && <CreatePolicyWizard

--- a/src/pages/PolicyDetail/Skeleton.tsx
+++ b/src/pages/PolicyDetail/Skeleton.tsx
@@ -3,13 +3,13 @@ import { Main, PageHeader, PageHeaderTitle, Skeleton, Spinner } from '@redhat-cl
 import {
     Breadcrumb,
     Bullseye,
-    Dropdown,
-    KebabToggle,
+    Button, ButtonVariant,
     Split,
     SplitItem,
     Stack,
     StackItem
 } from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons';
 import { Section } from '../../components/FrontendComponents/Section';
 import { BreadcrumbLinkItem } from '../../components/Wrappers/BreadcrumbLinkItem';
 import { linkTo } from '../../Routes';
@@ -33,10 +33,7 @@ export const PolicyDetailSkeleton: React.FunctionComponent = () => {
                                 <PageHeaderTitle title={ <Skeleton size="sm"/> } />
                             </SplitItem>
                             <SplitItem>
-                                <Dropdown toggle={ <KebabToggle
-                                    isDisabled={ true }
-                                /> }
-                                />
+                                <Button isDisabled variant={ ButtonVariant.plain }><EllipsisVIcon/></Button>
                             </SplitItem>
                         </Split>
                     </StackItem>

--- a/src/pages/PolicyDetail/Skeleton.tsx
+++ b/src/pages/PolicyDetail/Skeleton.tsx
@@ -3,8 +3,8 @@ import { Main, PageHeader, PageHeaderTitle, Skeleton, Spinner } from '@redhat-cl
 import {
     Breadcrumb,
     Bullseye,
-    Button,
-    ButtonVariant,
+    Dropdown,
+    KebabToggle,
     Split,
     SplitItem,
     Stack,
@@ -33,12 +33,10 @@ export const PolicyDetailSkeleton: React.FunctionComponent = () => {
                                 <PageHeaderTitle title={ <Skeleton size="sm"/> } />
                             </SplitItem>
                             <SplitItem>
-                                <Button
-                                    variant={ ButtonVariant.secondary }
+                                <Dropdown toggle={ <KebabToggle
                                     isDisabled={ true }
-                                >
-                                    Edit policy
-                                </Button>
+                                /> }
+                                />
                             </SplitItem>
                         </Split>
                     </StackItem>

--- a/src/pages/PolicyDetail/TriggerEmptyState.tsx
+++ b/src/pages/PolicyDetail/TriggerEmptyState.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { CubesIcon } from '@patternfly/react-icons';
+import { Messages } from '../../properties/Messages';
+import { EmptyStateSection } from '../../components/Policy/EmptyState/Section';
+
+export const PolicyDetailTriggerEmptyState: React.FunctionComponent = () => {
+    return <EmptyStateSection
+        icon={ CubesIcon }
+        title={ Messages.pages.policyDetail.triggerEmptyState.title }
+        content={ Messages.pages.policyDetail.triggerEmptyState.text }
+    />;
+};

--- a/src/pages/PolicyDetail/TriggerEmptyState.tsx
+++ b/src/pages/PolicyDetail/TriggerEmptyState.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { CubesIcon } from '@patternfly/react-icons';
 import { Messages } from '../../properties/Messages';
 import { EmptyStateSection } from '../../components/Policy/EmptyState/Section';
 
 export const PolicyDetailTriggerEmptyState: React.FunctionComponent = () => {
     return <EmptyStateSection
-        icon={ CubesIcon }
         title={ Messages.pages.policyDetail.triggerEmptyState.title }
         content={ Messages.pages.policyDetail.triggerEmptyState.text }
     />;

--- a/src/pages/PolicyDetail/__tests__/Actions.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/Actions.test.tsx
@@ -1,0 +1,175 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PolicyDetailActions } from '../Actions';
+
+describe('src/pages/PolicyDetail/Actions', () => {
+    it('Renders menu', () => {
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ true }
+            loadingEnabledChange={ false }
+        />);
+
+        expect(screen.getByRole('button')).toBeVisible();
+    });
+
+    it('Shows menu with disable when isEnabled is true', () => {
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ true }
+            loadingEnabledChange={ false }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+
+        expect(screen.queryByText(/enable/i)).toBeFalsy();
+        expect(screen.getByText(/disable/i)).toBeVisible();
+        expect(screen.getByText(/edit/i)).toBeVisible();
+        expect(screen.getByText(/duplicate/i)).toBeVisible();
+        expect(screen.getByText(/delete/i)).toBeVisible();
+    });
+
+    it('Shows menu with enable when isEnabled is false', () => {
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ false }
+            loadingEnabledChange={ false }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+
+        expect(screen.queryByText(/disable/i)).toBeFalsy();
+        expect(screen.getByText(/enable/i)).toBeVisible();
+        expect(screen.getByText(/edit/i)).toBeVisible();
+        expect(screen.getByText(/duplicate/i)).toBeVisible();
+        expect(screen.getByText(/delete/i)).toBeVisible();
+    });
+
+    it('Calls changeEnabled with true when clicking enable', () => {
+        const changeEnabled = jest.fn();
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ changeEnabled }
+            disabled={ false }
+            isEnabled={ false }
+            loadingEnabledChange={ false }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+        userEvent.click(screen.getByText(/enable/i));
+        expect(changeEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('Calls changeEnabled with false when clicking disable', () => {
+        const changeEnabled = jest.fn();
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ changeEnabled }
+            disabled={ false }
+            isEnabled={ true }
+            loadingEnabledChange={ false }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+        userEvent.click(screen.getByText(/disable/i));
+        expect(changeEnabled).toHaveBeenCalledWith(false);
+    });
+
+    it('enable button is disabled when loadingEnabledChange', () => {
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ false }
+            loadingEnabledChange={ true }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+        expect(screen.getByText(/enable/i)).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('disable button is disabled when loadingEnabledChange', () => {
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ true }
+            loadingEnabledChange={ true }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+        expect(screen.getByText(/disable/i)).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('Calls edit when clicking', () => {
+        const edit = jest.fn();
+        render(<PolicyDetailActions
+            edit={ edit }
+            duplicate={ jest.fn() }
+            delete={ jest.fn() }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ false }
+            loadingEnabledChange={ false }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+        userEvent.click(screen.getByText(/edit/i));
+        expect(edit).toHaveBeenCalled();
+    });
+
+    it('Calls duplicate when clicking', () => {
+        const duplicate = jest.fn();
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ duplicate }
+            delete={ jest.fn() }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ false }
+            loadingEnabledChange={ false }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+        userEvent.click(screen.getByText(/duplicate/i));
+        expect(duplicate).toHaveBeenCalled();
+    });
+
+    it('Calls delete when clicking', () => {
+        const deleteFn = jest.fn();
+        render(<PolicyDetailActions
+            edit={ jest.fn() }
+            duplicate={ jest.fn() }
+            delete={ deleteFn }
+            changeEnabled={ jest.fn() }
+            disabled={ false }
+            isEnabled={ false }
+            loadingEnabledChange={ false }
+        />);
+
+        userEvent.click(screen.getByRole('button'));
+        userEvent.click(screen.getByText(/delete/i));
+        expect(deleteFn).toHaveBeenCalled();
+    });
+});

--- a/src/pages/PolicyDetail/__tests__/IsEnabled.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/IsEnabled.test.tsx
@@ -5,7 +5,7 @@ import { PolicyDetailIsEnabled } from '../IsEnabled';
 import { useMassChangePolicyEnabledMutation } from '../../../services/useMassChangePolicyEnabled';
 
 jest.mock('../../../services/useMassChangePolicyEnabled');
-
+/*
 describe('src/pages/PolicyDetail/IsEnabled', () => {
 
     const mockMutation = (loading: boolean) => {
@@ -98,3 +98,4 @@ describe('src/pages/PolicyDetail/IsEnabled', () => {
         expect(statusChanged).toHaveBeenCalledWith(false);
     });
 });
+*/

--- a/src/pages/PolicyDetail/__tests__/IsEnabled.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/IsEnabled.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { render, screen, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { PolicyDetailIsEnabled } from '../IsEnabled';
 import { useMassChangePolicyEnabledMutation } from '../../../services/useMassChangePolicyEnabled';
 

--- a/src/pages/PolicyDetail/__tests__/IsEnabled.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/IsEnabled.test.tsx
@@ -5,7 +5,7 @@ import { PolicyDetailIsEnabled } from '../IsEnabled';
 import { useMassChangePolicyEnabledMutation } from '../../../services/useMassChangePolicyEnabled';
 
 jest.mock('../../../services/useMassChangePolicyEnabled');
-/*
+
 describe('src/pages/PolicyDetail/IsEnabled', () => {
 
     const mockMutation = (loading: boolean) => {
@@ -26,76 +26,27 @@ describe('src/pages/PolicyDetail/IsEnabled', () => {
 
     it('Renders "Enabled" if isEnabled is true', () => {
         render(<PolicyDetailIsEnabled
-            policyId={ 'foo-id' }
             isEnabled={ true }
-            statusChanged={ jest.fn() }
+            loading={ false }
         />);
         expect(screen.getByText('Enabled')).toBeVisible();
     });
 
     it('Renders "Disabled" if isEnabled is false', () => {
         render(<PolicyDetailIsEnabled
-            policyId={ 'foo-id' }
             isEnabled={ false }
-            statusChanged={ jest.fn() }
+            loading={ false }
         />);
         expect(screen.getByText('Disabled')).toBeVisible();
     });
 
-    it('Renders button to disable policies when isEnabled is true', () => {
-        render(<PolicyDetailIsEnabled
-            policyId={ 'foo-id' }
-            isEnabled={ true }
-            statusChanged={ jest.fn() }
-        />);
-        expect(screen.getByText('Disable policy')).toBeVisible();
-    });
-
-    it('Renders button to enable policies when isEnabled is false', () => {
-        render(<PolicyDetailIsEnabled
-            policyId={ 'foo-id' }
-            isEnabled={ false }
-            statusChanged={ jest.fn() }
-        />);
-        expect(screen.getByText('Enable policy')).toBeVisible();
-    });
-
-    it('policyId and !isEnabled is passed to the mutation when clicking the link', () => {
-        const mutation = mockMutation(false);
-        render(<PolicyDetailIsEnabled
-            policyId={ 'foo-id' }
-            isEnabled={ true }
-            statusChanged={ jest.fn() }
-        />);
-        userEvent.click(screen.getByRole('button'));
-        expect(mutation).toHaveBeenCalledWith({
-            policyIds: [ 'foo-id' ],
-            shouldBeEnabled: false
-        });
-    });
-
-    it('Loading is show when fetching', () => {
+    it('Loading is show when loading is true', () => {
         mockMutation(true);
         render(<PolicyDetailIsEnabled
-            policyId={ 'foo-id' }
+            loading={ true }
             isEnabled={ true }
-            statusChanged={ jest.fn() }
         />);
         expect(screen.getByTestId('loading')).toBeVisible();
     });
-
-    it('Status changed is called when finished the isEnabled change with the new isEnabled value', async () => {
-        const statusChanged = jest.fn();
-        render(<PolicyDetailIsEnabled
-            policyId={ 'foo-id' }
-            isEnabled={ true }
-            statusChanged={ statusChanged }
-        />);
-        userEvent.click(screen.getByRole('button'));
-        await act(async () => {
-
-        });
-        expect(statusChanged).toHaveBeenCalledWith(false);
-    });
 });
-*/
+

--- a/src/pages/PolicyDetail/__tests__/PolicyDetail.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/PolicyDetail.test.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { PolicyDetail } from '../PolicyDetail';
+import { appWrapperCleanup, appWrapperSetup, getConfiguredAppWrapper } from '../../../../test/AppWrapper';
+import { linkTo } from '../../../Routes';
+import fetchMock = require('fetch-mock');
+import { actionGetPoliciesById, actionGetPoliciesByIdHistoryTrigger } from '../../../generated/ActionCreators';
+
+describe('src/Pages/PolicyDetail/PolicyDetail', () => {
+
+    beforeEach(() => {
+        appWrapperSetup();
+    });
+
+    afterEach(() => {
+        appWrapperCleanup();
+    });
+
+    const fetchMockDefaultPolicy = () => {
+        fetchMock.getOnce(actionGetPoliciesById({
+            id: 'foo'
+        }).endpoint, {
+            body: {
+                actions: 'email',
+                conditions: 'facts.arch = "x86_64"',
+                ctime: '2020-06-02 16:11:09.622',
+                description: 'Fail if we are running on a x86_64',
+                id: 'foo',
+                isEnabled: true,
+                lastTriggered: 1591132435642,
+                mtime: '2020-06-02 16:11:48.428',
+                name: 'Not arch x86_64'
+            },
+            status: 200
+        });
+
+        fetchMock.getOnce(actionGetPoliciesByIdHistoryTrigger({
+            id: 'foo'
+        }).endpoint, {
+            body: [
+                {
+                    ctime: 1591132431400,
+                    hostName: 'foo-bar',
+                    id: 'my-stuff'
+                },
+                {
+                    ctime: 1591132404157,
+                    hostName: 'random host',
+                    id: 'foo-bar-id'
+                },
+                {
+                    ctime: 1591132300131,
+                    hostName: 'random host',
+                    id: 'foo-bar-id'
+                },
+                {
+                    ctime: 1591132299051,
+                    hostName: 'foo-bar',
+                    id: 'my-stuff'
+                }
+            ]
+        });
+    };
+
+    it('Refuses to show data if rbac.readAll is false', async () => {
+        fetchMockDefaultPolicy();
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                },
+                appContext: {
+                    rbac: {
+                        canWriteAll: true,
+                        canReadAll: false
+                    },
+                    userSettings: {
+                        isSubscribedForNotifications: false,
+                        refresh: () => '',
+                        settings: undefined
+                    }
+                }
+            })
+        });
+
+        await act(async () => {
+
+        });
+
+        expect(screen.getByText('You do not have access to Policies')).toBeVisible();
+    });
+
+    it('Renders policy data', async () => {
+        fetchMockDefaultPolicy();
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await act(async () => {
+
+        });
+
+        expect(screen.getByText('Not arch x86_64', {
+            selector: 'h1'
+        })).toBeVisible();
+        expect(screen.getByText('Enabled')).toBeVisible();
+        expect(screen.queryAllByText('foo-bar').length).toBe(2);
+        expect(screen.queryAllByText('random host').length).toBe(2);
+    });
+
+    it('Sorts date descending by default ', async () => {
+        fetchMockDefaultPolicy();
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await act(async () => {
+
+        });
+        expect(screen.getByText(/date/i, {
+            selector: 'th > button'
+        }).parentElement).toHaveAttribute('aria-sort', 'descending');
+    });
+});

--- a/src/pages/PolicyDetail/__tests__/PolicyDetail.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/PolicyDetail.test.tsx
@@ -1,10 +1,22 @@
 import * as React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import fetchMock = require('fetch-mock');
+import { render, screen, getByRole } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import inBrowserDownload from 'in-browser-download';
 import { PolicyDetail } from '../PolicyDetail';
 import { appWrapperCleanup, appWrapperSetup, getConfiguredAppWrapper } from '../../../../test/AppWrapper';
 import { linkTo } from '../../../Routes';
-import fetchMock = require('fetch-mock');
-import { actionGetPoliciesById, actionGetPoliciesByIdHistoryTrigger } from '../../../generated/ActionCreators';
+import {
+    actionDeletePoliciesIds,
+    actionGetPoliciesById,
+    actionGetPoliciesByIdHistoryTrigger, actionPostPolicies, actionPostPoliciesIdsEnabled, actionPostPoliciesValidate,
+    actionPostPoliciesValidateName, actionPutPoliciesByPolicyId
+} from '../../../generated/ActionCreators';
+import { waitForAsyncEvents } from '../../../../test/TestUtils';
+import { ServerPolicyRequest } from '../../../types/Policy/Policy';
+
+jest.mock('../../../hooks/useFacts');
+jest.mock('in-browser-download', () => jest.fn());
 
 describe('src/Pages/PolicyDetail/PolicyDetail', () => {
 
@@ -16,54 +28,126 @@ describe('src/Pages/PolicyDetail/PolicyDetail', () => {
         appWrapperCleanup();
     });
 
-    const fetchMockDefaultPolicy = () => {
+    type FetchMockConfig = {
+        policyStatus?: number;
+        policyIsUndefined?: boolean;
+        policyId?: string;
+        policy?: any;
+        triggers?: any;
+    };
+
+    const mockPolicy = {
+        actions: 'email',
+        conditions: 'facts.arch = "x86_64"',
+        ctime: '2020-06-02 16:11:09.622',
+        description: 'Fail if we are running on a x86_64',
+        id: 'foo',
+        isEnabled: true,
+        lastTriggered: 1591132435642,
+        mtime: '2020-06-02 16:11:48.428',
+        name: 'Not arch x86_64'
+    };
+
+    const mockTriggers = [
+        {
+            ctime: 1591132431400,
+            hostName: 'foo-bar',
+            id: 'my-stuff'
+        },
+        {
+            ctime: 1591132404157,
+            hostName: 'random host',
+            id: 'foo-bar-id'
+        },
+        {
+            ctime: 1591132300131,
+            hostName: 'random host',
+            id: 'foo-bar-id'
+        },
+        {
+            ctime: 1591132299051,
+            hostName: 'foo-bar',
+            id: 'my-stuff'
+        }
+    ];
+
+    const fetchMockSetup = (config?: FetchMockConfig) => {
         fetchMock.getOnce(actionGetPoliciesById({
-            id: 'foo'
+            id: config?.policyId || 'foo'
         }).endpoint, {
-            body: {
-                actions: 'email',
-                conditions: 'facts.arch = "x86_64"',
-                ctime: '2020-06-02 16:11:09.622',
-                description: 'Fail if we are running on a x86_64',
-                id: 'foo',
-                isEnabled: true,
-                lastTriggered: 1591132435642,
-                mtime: '2020-06-02 16:11:48.428',
-                name: 'Not arch x86_64'
-            },
-            status: 200
+            body: config?.policyIsUndefined === true ? undefined : (config?.policy || mockPolicy),
+            status: config?.policyStatus || 200
+        }, {
+            overwriteRoutes: false
         });
 
         fetchMock.getOnce(actionGetPoliciesByIdHistoryTrigger({
-            id: 'foo'
+            id: config?.policyId || 'foo'
         }).endpoint, {
-            body: [
-                {
-                    ctime: 1591132431400,
-                    hostName: 'foo-bar',
-                    id: 'my-stuff'
-                },
-                {
-                    ctime: 1591132404157,
-                    hostName: 'random host',
-                    id: 'foo-bar-id'
-                },
-                {
-                    ctime: 1591132300131,
-                    hostName: 'random host',
-                    id: 'foo-bar-id'
-                },
-                {
-                    ctime: 1591132299051,
-                    hostName: 'foo-bar',
-                    id: 'my-stuff'
-                }
-            ]
+            body: (config?.triggers || mockTriggers)
+        }, {
+            overwriteRoutes: false
+        });
+    };
+
+    const fetcMockValidateName = (id?: string) => {
+        fetchMock.postOnce(actionPostPoliciesValidateName({
+            body: 'foo',
+            id
+        }).endpoint, {
+            status: 200
+        });
+    };
+
+    const fetchMockValidateCondition = () => {
+        fetchMock.postOnce(actionPostPoliciesValidate({
+            body: undefined
+        }).endpoint, {
+            status: 200
+        });
+    };
+
+    const fetchMockSavePolicy = (edit: boolean, updatePolicy: Partial<ServerPolicyRequest>) => {
+        const policy = { ...mockPolicy, ...updatePolicy };
+
+        if (edit) {
+            fetchMock.putOnce(actionPutPoliciesByPolicyId({
+                policyId: policy.id,
+                body: policy
+            }).endpoint, {
+                status: 200,
+                body: policy
+            });
+        } else {
+            fetchMock.postOnce(actionPostPolicies({
+                alsoStore: true,
+                body: mockPolicy
+            }).endpoint, {
+                status: 200,
+                body: policy
+            });
+        }
+    };
+
+    const fetchMockDelete = () => {
+        fetchMock.deleteOnce(actionDeletePoliciesIds({
+            body: []
+        }).endpoint, {
+            status: 200,
+            body: [ 'foo' ]
+        });
+    };
+
+    const fetchMockChangeStatus = (enabled: boolean) => {
+        fetchMock.postOnce(actionPostPoliciesIdsEnabled({
+            enabled
+        }).endpoint, {
+            body: []
         });
     };
 
     it('Refuses to show data if rbac.readAll is false', async () => {
-        fetchMockDefaultPolicy();
+        fetchMockSetup();
         render(<PolicyDetail/>, {
             wrapper: getConfiguredAppWrapper({
                 router: {
@@ -86,15 +170,12 @@ describe('src/Pages/PolicyDetail/PolicyDetail', () => {
             })
         });
 
-        await act(async () => {
-
-        });
-
+        await waitForAsyncEvents();
         expect(screen.getByText('You do not have access to Policies')).toBeVisible();
     });
 
     it('Renders policy data', async () => {
-        fetchMockDefaultPolicy();
+        fetchMockSetup();
         render(<PolicyDetail/>, {
             wrapper: getConfiguredAppWrapper({
                 router: {
@@ -106,10 +187,7 @@ describe('src/Pages/PolicyDetail/PolicyDetail', () => {
             })
         });
 
-        await act(async () => {
-
-        });
-
+        await waitForAsyncEvents();
         expect(screen.getByText('Not arch x86_64', {
             selector: 'h1'
         })).toBeVisible();
@@ -119,7 +197,7 @@ describe('src/Pages/PolicyDetail/PolicyDetail', () => {
     });
 
     it('Sorts date descending by default ', async () => {
-        fetchMockDefaultPolicy();
+        fetchMockSetup();
         render(<PolicyDetail/>, {
             wrapper: getConfiguredAppWrapper({
                 router: {
@@ -131,11 +209,398 @@ describe('src/Pages/PolicyDetail/PolicyDetail', () => {
             })
         });
 
-        await act(async () => {
-
-        });
+        await waitForAsyncEvents();
         expect(screen.getByText(/date/i, {
             selector: 'th > button'
         }).parentElement).toHaveAttribute('aria-sort', 'descending');
+    });
+
+    it('Shows empty state when policy is not found ', async () => {
+        fetchMockSetup({
+            policyStatus: 404,
+            policyIsUndefined: true
+        });
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        expect(screen.getByText(/Policy not found/i)).toBeVisible();
+    });
+
+    it('Shows error state when policy is has status different than 200 or 404 ', async () => {
+        fetchMockSetup({
+            policyStatus: 500,
+            policy: {
+                msg: 'this looks bad'
+            }
+        });
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        expect(screen.getByText(/this looks bad/i)).toBeVisible();
+    });
+
+    it('Shows error state when policy is has status different than 200 or 404, show status when no error msg', async () => {
+        fetchMockSetup({
+            policyStatus: 500,
+            policy: {}
+        });
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        expect(screen.getByText(/code: 500/i)).toBeVisible();
+    });
+
+    it('On the error state, clicking on the button retries the query', async () => {
+        fetchMockSetup({
+            policyStatus: 500,
+            policy: {}
+        });
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        fetchMockSetup({
+            policyStatus: 200
+        });
+        userEvent.click(screen.getByRole('button'));
+
+        await waitForAsyncEvents();
+        expect(screen.getAllByText(/Not arch x86/i)).toBeTruthy();
+    });
+
+    it('Click on edit brings up edit wizard ', async () => {
+        fetchMockSetup();
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/edit/i));
+
+        await waitForAsyncEvents();
+        expect(screen.getByText(/Edit a policy/i)).toBeVisible();
+    });
+
+    it('Click on duplicate brings up create wizard ', async () => {
+        fetchMockSetup();
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/duplicate/i));
+
+        await waitForAsyncEvents();
+        expect(screen.getByText(/Create a policy/i)).toBeVisible();
+        expect(screen.getByDisplayValue(/Copy of Not arch x86_64/i)).toBeVisible();
+    });
+
+    it('Duplicates navigates to the new policy url ', async () => {
+        fetchMockSetup();
+        fetcMockValidateName(undefined);
+        fetchMockValidateCondition();
+        fetchMockSavePolicy(false, {
+            id: 'bar-123'
+        });
+        fetchMockSetup({
+            policyId: 'bar-123'
+        });
+
+        const getLocation = jest.fn();
+
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                },
+                getLocation
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/duplicate/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Next/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Validate/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Next/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Next/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Finish/i));
+        await waitForAsyncEvents();
+        expect(getLocation().pathname).toEqual(linkTo.policyDetail('bar-123'));
+    });
+
+    it('Edits updates the policy with the new values ', async () => {
+        fetchMockSetup();
+        fetcMockValidateName('foo');
+        fetchMockValidateCondition();
+        fetchMockSavePolicy(true, {
+            name: 'my new name'
+        });
+
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/edit/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Next/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Next/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Next/i));
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText(/Finish/i));
+        await waitForAsyncEvents();
+        expect(screen.getAllByText('my new name')).toBeTruthy();
+    });
+
+    it('Click on delete brings up the delete dialog ', async () => {
+        fetchMockSetup();
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/delete/i));
+
+        await waitForAsyncEvents();
+        expect(screen.getByText(/Do you want to delete the policy/i)).toBeVisible();
+    });
+
+    it('Delete dialog can be closed ', async () => {
+        fetchMockSetup();
+        render(<PolicyDetail/>, {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/delete/i));
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText('Cancel'));
+
+        await waitForAsyncEvents();
+        expect(screen.queryByText(/Do you want to delete the policy/i)).toBeFalsy();
+    });
+
+    it('When policy is deleted, navigates to list page', async () => {
+        fetchMockSetup();
+        fetchMockDelete();
+
+        const getLocation = jest.fn();
+        render((
+            <>
+                <PolicyDetail/>
+            </>
+        ), {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                },
+                getLocation
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/delete/i));
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByText('Delete'));
+
+        await waitForAsyncEvents();
+        expect(getLocation().pathname).toEqual(linkTo.listPage());
+    });
+    it('When policy is disabled, it updates the enabled status in the page', async () => {
+        fetchMockSetup();
+        fetchMockChangeStatus(false);
+        render((
+            <>
+                <PolicyDetail/>
+            </>
+        ), {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/disable/i));
+
+        await waitForAsyncEvents();
+        expect(screen.getByText('Disabled')).toBeVisible();
+    });
+
+    it('When policy is enabled, it updates the enabled status in the page to disabled', async () => {
+        fetchMockSetup({
+            policy: { ...mockPolicy, isEnabled: false }
+        });
+        fetchMockChangeStatus(true);
+        render((
+            <>
+                <PolicyDetail/>
+            </>
+        ), {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(screen.getByTestId('policy-detail-actions-button'));
+        userEvent.click(screen.getByText(/enable/i));
+
+        await waitForAsyncEvents();
+        expect(screen.getByText('Enabled')).toBeVisible();
+    });
+
+    it('Export button downloads a file with the current time', async () => {
+        fetchMockSetup();
+        const dateNow = jest.spyOn(Date, 'now');
+        dateNow.mockImplementation(() => new Date(2020, 10, 5).getTime());
+
+        render((
+            <>
+                <PolicyDetail/>
+            </>
+        ), {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        userEvent.click(getByRole(screen.getByTestId('trigger-toolbar-export-container'), 'button'));
+        userEvent.click(screen.getByText(/Export to JSON/i));
+
+        await waitForAsyncEvents();
+        expect(inBrowserDownload.mock.calls[0][1]).toEqual('policy-foo-triggers-2020-05-11.json');
+        dateNow.mockRestore();
+    });
+
+    it('Export button is not found when no triggers', async () => {
+        fetchMockSetup({
+            triggers: []
+        });
+        render((
+            <>
+                <PolicyDetail/>
+            </>
+        ), {
+            wrapper: getConfiguredAppWrapper({
+                router: {
+                    initialEntries: [ linkTo.policyDetail('foo') ]
+                },
+                route: {
+                    path: linkTo.policyDetail(':policyId')
+                }
+            })
+        });
+
+        await waitForAsyncEvents();
+        expect(screen.queryByTestId('trigger-toolbar-export-container')).toBeFalsy();
     });
 });

--- a/src/pages/PolicyDetail/__tests__/Skeleton.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/Skeleton.test.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PolicyDetailSkeleton } from '../Skeleton';
+import { AppWrapper, appWrapperCleanup, appWrapperSetup } from '../../../../test/AppWrapper';
+
+describe('src/pages/PolicyDetail/Skeleton', () => {
+
+    beforeEach(() => {
+        appWrapperSetup();
+    });
+
+    afterEach(() => {
+        appWrapperCleanup();
+    });
+
+    it('Renders breadcrumb policies with link to listPage', () => {
+        render(<PolicyDetailSkeleton/>, {
+            wrapper: AppWrapper
+        });
+
+        expect(screen.getByText(/Policies/i)).toHaveAttribute('href', '/list');
+    });
+
+    it('Renders Kebab button', () => {
+        render(<PolicyDetailSkeleton/>, {
+            wrapper: AppWrapper
+        });
+
+        expect(screen.getByRole('button')).toBeVisible();
+    });
+
+    it('Renders loading', () => {
+        render(<PolicyDetailSkeleton/>, {
+            wrapper: AppWrapper
+        });
+
+        expect(screen.getByText(/loading/i)).toBeVisible();
+    });
+});

--- a/src/pages/PolicyDetail/__tests__/TriggerEmptyState.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/TriggerEmptyState.test.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PolicyDetailTriggerEmptyState } from '../TriggerEmptyState';
+
+describe('src/pages/PolicyDetail/TriggerEmptyState', () => {
+    it('renders with No triggers found', () => {
+        render(<PolicyDetailTriggerEmptyState/>);
+        expect(screen.getByText(/No triggers found/i)).toBeVisible();
+    });
+});

--- a/src/pages/PolicyDetail/hooks/usePagedTriggers.ts
+++ b/src/pages/PolicyDetail/hooks/usePagedTriggers.ts
@@ -7,6 +7,7 @@ export interface UsePagedTriggersResponse {
     count: number;
     pagedTriggers: Array<Trigger>;
     processedTriggers: Array<Trigger>;
+    rawCount: number;
 }
 
 export const usePagedTriggers = (triggers: Array<Trigger> | undefined, page: Page): UsePagedTriggersResponse => {
@@ -58,6 +59,7 @@ export const usePagedTriggers = (triggers: Array<Trigger> | undefined, page: Pag
     return {
         count,
         pagedTriggers,
-        processedTriggers
+        processedTriggers,
+        rawCount: triggers ? triggers.length : 0
     };
 };

--- a/src/pages/PolicyDetail/hooks/usePolicy.ts
+++ b/src/pages/PolicyDetail/hooks/usePolicy.ts
@@ -1,0 +1,51 @@
+import { Policy } from '../../../types/Policy';
+import { Uuid } from '../../../types/Policy/Policy';
+import { useHistory, useParams } from 'react-router';
+import * as React from 'react';
+import { linkTo } from '../../../Routes';
+// This seems to be stable enough:
+// https://github.com/facebook/react/issues/14259#issuecomment-505918440
+// eslint-disable-next-line @typescript-eslint/camelcase
+import { unstable_batchedUpdates } from 'react-dom';
+import { useEffect } from 'react';
+import { usePrevious } from 'react-use';
+
+export const usePolicy = () => {
+
+    const { policyId: policyIdFromUrl } = useParams<{
+        policyId: string;
+    }>();
+    const prevPolicyIdFromUrl = usePrevious(policyIdFromUrl);
+    const history = useHistory();
+    const [ policy, setPolicyInternal ] = React.useState<Policy>();
+    const policyId = policy?.id || policyIdFromUrl;
+
+    const batchPolicyUpdate = React.useCallback((newPolicyId: Uuid, newPolicy: Policy | undefined) => {
+        unstable_batchedUpdates(() => {
+            setPolicyInternal(newPolicy);
+            history.push(linkTo.policyDetail(newPolicyId));
+        });
+    }, [ history, setPolicyInternal ]);
+
+    const setPolicy = React.useCallback((policy: Policy) => {
+        if (policyIdFromUrl !== policy.id) {
+            batchPolicyUpdate(policy.id, policy);
+        } else {
+            setPolicyInternal(policy);
+        }
+    }, [ batchPolicyUpdate, policyIdFromUrl ]);
+
+    useEffect(() => {
+        if (prevPolicyIdFromUrl !== policyIdFromUrl) {
+            if (!policy || policy.id !== policyIdFromUrl) {
+                setPolicyInternal(undefined);
+            }
+        }
+    }, [ policyIdFromUrl, prevPolicyIdFromUrl, batchPolicyUpdate, history, policy, policyId ]);
+
+    return {
+        policyId,
+        policy,
+        setPolicy
+    };
+};

--- a/src/pages/PolicyDetail/hooks/useTriggerPage.ts
+++ b/src/pages/PolicyDetail/hooks/useTriggerPage.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { Filter, Operator, Page, Sort } from '../../../types/Page';
 import { TriggerFilterColumn, TriggerFilters } from './useTriggerFilter';
 
-const elementsPerPage = 10;
+const elementsPerPage = 50;
 
 export const useTriggerPage = (sort: Sort | undefined, filters: TriggerFilters) => {
     const [ page, setPage ] = React.useState<Page>(() => Page.of(1, elementsPerPage));

--- a/src/pages/PolicyDetail/hooks/useWizardState.ts
+++ b/src/pages/PolicyDetail/hooks/useWizardState.ts
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { makeCopyOfPolicy } from '../../../types/adapters/PolicyAdapter';
+import { assertNever } from '../../../utils/Assert';
+import { NewPolicy, Policy } from '../../../types/Policy/Policy';
+import { useCallback } from 'react';
+
+type PolicyDetailWizardState = {
+    isOpen: boolean;
+    initialValue: NewPolicy | undefined;
+    isEditing: boolean;
+};
+
+enum PolicyDetailWizardAction {
+    EDIT,
+    DUPLICATE,
+    CLOSE
+}
+
+const closedState: PolicyDetailWizardState = {
+    isEditing: false,
+    initialValue: undefined,
+    isOpen: false
+};
+
+export const useWizardState = (policy: Policy | undefined) => {
+    const [ state, dispatch ] = React.useReducer((_prev, action: PolicyDetailWizardAction): PolicyDetailWizardState => {
+        if (!policy) {
+            return closedState;
+        }
+
+        switch (action) {
+            case PolicyDetailWizardAction.CLOSE:
+                return closedState;
+            case PolicyDetailWizardAction.DUPLICATE:
+                return {
+                    isEditing: false,
+                    initialValue: makeCopyOfPolicy(policy),
+                    isOpen: true
+                };
+            case PolicyDetailWizardAction.EDIT:
+                return {
+                    isEditing: true,
+                    initialValue: policy,
+                    isOpen: true
+                };
+            default:
+                assertNever(action);
+        }
+
+        return closedState;
+    }, closedState);
+
+    const close = useCallback(() => dispatch(PolicyDetailWizardAction.CLOSE), [ dispatch ]);
+    const duplicate = useCallback(() => dispatch(PolicyDetailWizardAction.DUPLICATE), [ dispatch ]);
+    const edit = useCallback(() => dispatch(PolicyDetailWizardAction.EDIT), [ dispatch ]);
+
+    return {
+        data: state,
+        close,
+        duplicate,
+        edit
+    };
+};

--- a/src/pages/PolicyDetail/hooks/useWizardState.ts
+++ b/src/pages/PolicyDetail/hooks/useWizardState.ts
@@ -44,10 +44,9 @@ export const useWizardState = (policy: Policy | undefined) => {
                     isOpen: true
                 };
             default:
-                assertNever(action);
+                return assertNever(action);
         }
 
-        return closedState;
     }, closedState);
 
     const close = useCallback(() => dispatch(PolicyDetailWizardAction.CLOSE), [ dispatch ]);

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -33,6 +33,10 @@ const MutableMessages = {
                 text: 'This policy with ID {0} cannot be found. It may have been deleted by another user.',
                 backText: 'Back to previous page'
             },
+            triggerEmptyState: {
+                title: 'No triggers found',
+                text: 'This policy does not have any recent triggers'
+            },
             errorState: {
                 title: 'Error when loading policy',
                 text: 'Error found when trying to load policy with ID {0}. (Error: {1})',
@@ -95,6 +99,12 @@ const MutableMessages = {
             columns: {
                 date: 'Date',
                 system: 'System'
+            },
+            emptyState: {
+                notFound: {
+                    title: 'No matching triggers found',
+                    content: 'No triggers matching the search terms.'
+                }
             }
         }
     },

--- a/src/services/useGetPolicy.ts
+++ b/src/services/useGetPolicy.ts
@@ -1,6 +1,6 @@
-import { useQuery } from 'react-fetching-library';
+import { useParameterizedQuery, useQuery } from 'react-fetching-library';
 import { actionGetPoliciesById } from '../generated/ActionCreators';
-import { Uuid } from '../types/Policy/Policy';
+import { ServerPolicyResponse, Uuid } from '../types/Policy/Policy';
 import { useTransformQueryResponse } from '../utils/ApiUtils';
 import { toPolicy } from '../types/adapters/PolicyAdapter';
 
@@ -13,6 +13,13 @@ export const actionCreator = (policyId: Uuid) => {
 export const useGetPolicyQuery = (policyId: Uuid, initFetch = true) => {
     return useTransformQueryResponse(
         useQuery(actionCreator(policyId), initFetch),
+        toPolicy
+    );
+};
+
+export const useGetPolicyParametrizedQuery = () => {
+    return useTransformQueryResponse(
+        useParameterizedQuery<ServerPolicyResponse>(actionCreator),
         toPolicy
     );
 };

--- a/src/services/useSavePolicy.ts
+++ b/src/services/useSavePolicy.ts
@@ -1,7 +1,8 @@
-import { NewPolicy } from '../types/Policy/Policy';
-import { toServerPolicy } from '../types/adapters/PolicyAdapter';
-import { useBulkMutation, useMutation } from 'react-fetching-library';
+import { NewPolicy, ServerPolicyResponse } from '../types/Policy/Policy';
+import { toPolicy, toServerPolicy } from '../types/adapters/PolicyAdapter';
+import { useMutation } from 'react-fetching-library';
 import { actionPostPolicies, actionPutPoliciesByPolicyId } from '../generated/ActionCreators';
+import { useTransformQueryResponse } from '../utils/ApiUtils';
 
 export const savePolicyActionCreator = (policy: NewPolicy) => {
     if (policy.id) {
@@ -17,6 +18,4 @@ export const savePolicyActionCreator = (policy: NewPolicy) => {
     });
 };
 
-export const useSavePolicyMutation = () => useMutation(savePolicyActionCreator);
-
-export const useBulkSavePolicyMutation = () => useBulkMutation(savePolicyActionCreator);
+export const useSavePolicyMutation = () => useTransformQueryResponse(useMutation<ServerPolicyResponse>(savePolicyActionCreator), toPolicy);

--- a/src/utils/ApiUtils.ts
+++ b/src/utils/ApiUtils.ts
@@ -9,11 +9,7 @@ const transformPayload = <FROM, TO>(payload: FROM | undefined, status: number | 
         return adapter(payload);
     }
 
-    if (status !== undefined && payload !== undefined) {
-        console.warn(`Payload: ${payload} ignored for status ${status}`);
-    }
-
-    return undefined;
+    return payload as any;
 };
 
 type ExpectedQueryResponse<FROM> = QueryResponse<FROM> & {

--- a/src/utils/ApiUtils.ts
+++ b/src/utils/ApiUtils.ts
@@ -1,38 +1,95 @@
 import * as React from 'react';
 import { QueryResponse } from 'react-fetching-library';
 
+// This will swallow payloads different than 200 or 201 for the methods using this transform.
+// An alternative would be to have specific adapters for each request, pass the payload and status and let
+// them transform or just pass the errors as needed.
 const transformPayload = <FROM, TO>(payload: FROM | undefined, status: number | undefined, adapter: (from: FROM) => TO): TO | undefined => {
-    return status === 200 && payload ? adapter(payload) : undefined;
+    if ((status === 200 || status === 201) && payload) {
+        return adapter(payload);
+    }
+
+    if (status !== undefined && payload !== undefined) {
+        console.warn(`Payload: ${payload} ignored for status ${status}`);
+    }
+
+    return undefined;
 };
 
 type ExpectedQueryResponse<FROM> = QueryResponse<FROM> & {
-    query: (action?: any) => Promise<QueryResponse<FROM>>;
+    query: (...args: Array<unknown>) => Promise<QueryResponse<FROM>>;
 }
 
-export const useTransformQueryResponse = <FROM, TO, USE_QUERY_RESPONSE_FROM extends ExpectedQueryResponse<FROM>>(
-    queryResponse: USE_QUERY_RESPONSE_FROM,
-    adapter: (from: FROM) => TO
-): Omit<USE_QUERY_RESPONSE_FROM, 'payload' | 'query'> & {
+type ExpectedMutateResponse<FROM> = QueryResponse<FROM> & {
+    mutate: (...args: Array<unknown>) => Promise<QueryResponse<FROM>>;
+}
+
+type UseTransformQueryResponseTypeQuery<
+    FROM,
+    USE_QUERY_RESPONSE_FROM extends ExpectedQueryResponse<FROM>,
+    TO
+    > = Omit<USE_QUERY_RESPONSE_FROM, 'payload' | 'query'> & {
     query: (...args: Parameters<USE_QUERY_RESPONSE_FROM['query']>) => Promise<QueryResponse<TO>>;
     payload: undefined | TO;
-} => {
-    const { payload, query, status } = queryResponse;
+};
 
-    const transformedQuery = React.useCallback((...args: Parameters<USE_QUERY_RESPONSE_FROM['query']>): Promise<QueryResponse<TO>> => {
-        return query(...args).then(response => ({
-            ...response,
-            payload: transformPayload(response.payload, response.status, adapter)
-        }));
-    }, [ query, adapter ]);
+type UseTransformQueryResponseTypeMutation<
+    FROM,
+    USE_QUERY_RESPONSE_FROM extends ExpectedMutateResponse<FROM>,
+    TO
+    > = Omit<USE_QUERY_RESPONSE_FROM, 'payload' | 'mutate'> & {
+    mutate: (...args: Parameters<USE_QUERY_RESPONSE_FROM['mutate']>) => Promise<QueryResponse<TO>>;
+    payload: undefined | TO;
+};
+
+interface UseTransformQueryResponseType {
+    <FROM, TO, USE_QUERY_RESPONSE_FROM extends ExpectedQueryResponse<FROM>>(queryResponse: USE_QUERY_RESPONSE_FROM, adapter: (from: FROM) => TO):
+        UseTransformQueryResponseTypeQuery<FROM, USE_QUERY_RESPONSE_FROM, TO>;
+    <FROM, TO, USE_MUTATE_RESPONSE_FROM extends ExpectedMutateResponse<FROM>>(queryResponse: USE_MUTATE_RESPONSE_FROM, adapter: (from: FROM) => TO):
+        UseTransformQueryResponseTypeMutation<FROM, USE_MUTATE_RESPONSE_FROM, TO>;
+}
+
+const isQuery = <T>(response): response is ExpectedQueryResponse<T> => {
+    return response.hasOwnProperty('query');
+};
+
+const isMutate = <T>(response): response is ExpectedMutateResponse<T> => {
+    return response.hasOwnProperty('mutate');
+};
+
+export const useTransformQueryResponse: UseTransformQueryResponseType = <FROM, TO, USE_QUERY_RESPONSE_FROM>(
+    queryResponse: USE_QUERY_RESPONSE_FROM,
+    adapter: (from: FROM) => TO
+) => {
+
+    if (!isQuery<FROM>(queryResponse) && !isMutate<FROM>(queryResponse)) {
+        throw new Error('Invalid query response provided to useTransformQueryResponse');
+    }
+
+    const response: ExpectedQueryResponse<FROM> | ExpectedMutateResponse<FROM> = queryResponse;
+
+    const { payload, status } = response;
 
     const transformedPayload = React.useMemo<TO | undefined>(
         () => transformPayload(payload, status, adapter),
         [ adapter, payload, status ]
     );
 
+    const field = isQuery(queryResponse) ? 'query' : 'mutate';
+    const func = isQuery(queryResponse) ? queryResponse.query : queryResponse.mutate;
+
+    const transformedQuery = React.useCallback((...args: Array<unknown>): Promise<QueryResponse<TO>> => {
+        return func(...args).then(response => {
+            return {
+                ...response,
+                payload: transformPayload(response.payload, response.status, adapter)
+            };
+        });
+    }, [ func, adapter ]);
+
     return {
         ...queryResponse,
         payload: transformedPayload,
-        query: transformedQuery
+        [field]: transformedQuery
     };
 };

--- a/src/utils/__tests__/ApiUtils.test.ts
+++ b/src/utils/__tests__/ApiUtils.test.ts
@@ -18,8 +18,7 @@ describe('src/utils/ApiUtils', () => {
         expect(result.current.payload).toBe(5);
     });
 
-    // Todo: We might need to include the error types on the query response to lift-up the only-status-200 restriction
-    it('transforms payload to undefined if status is not 200', () => {
+    it('keeps payload if status is not 200', () => {
         const response: UseQueryResponse<string> = {
             payload: 'error response',
             status: 404,
@@ -31,7 +30,7 @@ describe('src/utils/ApiUtils', () => {
         };
 
         const { result } = renderHook(() => useTransformQueryResponse(response, (val: string) => +val));
-        expect(result.current.payload).toBe(undefined);
+        expect(result.current.payload).toBe('error response');
     });
 
     it('transforms query promises to use the adapters in case of status 200', async () => {
@@ -55,7 +54,7 @@ describe('src/utils/ApiUtils', () => {
         return expect(queryResponse.payload).toBe(33);
     });
 
-    it('transforms query promises to return undefined if status is not 200', async () => {
+    it('keeps query promises to return the payload if status is not 200', async () => {
         const response: UseQueryResponse<string> = {
             payload: undefined,
             status: undefined,
@@ -73,7 +72,7 @@ describe('src/utils/ApiUtils', () => {
         const { result } = renderHook(() => useTransformQueryResponse(response, (val: string) => +val));
         const queryResponse = await result.current.query();
 
-        return expect(queryResponse.payload).toBe(undefined);
+        return expect(queryResponse.payload).toBe('33');
     });
 
 });

--- a/src/utils/exporters/Policy/__tests__/Csv.test.ts
+++ b/src/utils/exporters/Policy/__tests__/Csv.test.ts
@@ -36,11 +36,15 @@ describe('src/utils/exporters/Policy/Csv', () => {
         ]);
 
         const reader = new FileReader();
-        return new Promise((done) => {
+        return new Promise((done, fail) => {
             reader.addEventListener('loadend', () => {
-                const text = (reader.result as string).split('\r');
-                expect(text[0]).toEqual('id,name,description,isEnabled,conditions,actions,lastTriggered,mtime,ctime');
-                done();
+                try {
+                    const text = (reader.result as string).split('\r');
+                    expect(text[0]).toEqual('id,name,description,isEnabled,conditions,actions,lastTriggered,mtime,ctime');
+                    done();
+                } catch (ex) {
+                    fail(ex);
+                }
             });
             reader.readAsText(result);
         });

--- a/src/utils/exporters/Trigger/Csv.ts
+++ b/src/utils/exporters/Trigger/Csv.ts
@@ -9,9 +9,9 @@ export class TriggerExporterCsv extends ExporterCsv<Trigger> {
 
     public headers(): ExporterHeaders<TriggerExporterCsv, Trigger> {
         return [
-            [ 'id', 'id' ],
+            [ 'created', 'ctime' ],
             [ 'hostName', 'system' ],
-            [ 'created', 'ctime' ]
+            [ 'id', 'id' ]
         ];
     }
 }

--- a/src/utils/exporters/Trigger/__tests__/Csv.test.ts
+++ b/src/utils/exporters/Trigger/__tests__/Csv.test.ts
@@ -12,7 +12,7 @@ describe('src/utils/exporters/Trigger/Csv', () => {
         expect(result.type).toEqual('text/csv');
     });
 
-    it('has 9 columns', () => {
+    it('has 3 columns', () => {
         const result = new TriggerExporterCsv().export([
             {
                 id: '12345',
@@ -22,11 +22,15 @@ describe('src/utils/exporters/Trigger/Csv', () => {
         ]);
 
         const reader = new FileReader();
-        return new Promise((done) => {
+        return new Promise((done, fail) => {
             reader.addEventListener('loadend', () => {
-                const text = (reader.result as string).split('\r');
-                expect(text[0]).toEqual('id,system,ctime');
-                done();
+                try {
+                    const text = (reader.result as string).split('\r');
+                    expect(text[0]).toEqual('ctime,system,id');
+                    done();
+                } catch (ex) {
+                    fail(ex);
+                }
             });
             reader.readAsText(result);
         });

--- a/test/AppWrapper.tsx
+++ b/test/AppWrapper.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import { init } from '../src/store';
+import { RouteProps, Route } from 'react-router';
 import { MemoryRouter as Router } from 'react-router-dom';
 import { ClientContextProvider, createClient } from 'react-fetching-library';
 import { Provider } from 'react-redux';
 import fetchMock = require('fetch-mock');
+import { MemoryRouterProps } from 'react-router';
+import { AppContext } from '../src/app/AppContext';
 
 let setup = false;
 let client;
@@ -38,18 +41,50 @@ export const appWrapperCleanup = () => {
     }
 };
 
-export const AppWrapper: React.FunctionComponent = (props) => {
+type Config = {
+    router?: MemoryRouterProps;
+    route?: RouteProps;
+    appContext?: AppContext;
+}
+
+const defaultAppContextSettings = {
+    rbac: {
+        canReadAll: true,
+        canWriteAll: true
+    },
+    userSettings: {
+        settings: undefined,
+        isSubscribedForNotifications: false,
+        refresh: () => {}
+    }
+};
+
+export const AppWrapper: React.FunctionComponent<Config> = (props) => {
     if (!setup) {
         throw new Error('appWrapperSetup has not been called, you need to call it on the beforeEach');
     }
 
     return (
         <Provider store={ store }>
-            <Router>
-                <ClientContextProvider client={ client }>
-                    { props.children }
-                </ClientContextProvider>
+            <Router { ...props.router } >
+                <Route { ...props.route } >
+                    <ClientContextProvider client={ client }>
+                        <AppContext.Provider value={ props.appContext || defaultAppContextSettings }>
+                            { props.children }
+                        </AppContext.Provider>
+                    </ClientContextProvider>
+                </Route>
             </Router>
         </Provider>
     );
+};
+
+export const getConfiguredAppWrapper = (config?: Config) => {
+    const ConfiguredAppWrapper: React.FunctionComponent = (props) => {
+        return (
+            <AppWrapper { ...config }>{ props.children }</AppWrapper>
+        );
+    };
+
+    return ConfiguredAppWrapper;
 };

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -1,0 +1,7 @@
+import { act } from '@testing-library/react';
+
+export const waitForAsyncEvents = async () => {
+    await act(async () => {
+
+    });
+};


### PR DESCRIPTION
Now that the ui-backend has everything we need, stopped the work on #157 (which has enough changes already) and will start to work on this in whatever other improvements are needed there.

- Empty states for triggers
   - No triggers
   - Filter yield no triggers
- Changed "Edit Button" to kebab with more actions (edit, duplicate, delete, enable/disable)
- Removed inline "enable/disable"
- Defaults to sorting by date (triggers)
- Adds links to inventory (for triggers that we know its id, otherwise is still text)


~~So far I added 2 empty state for the triggers, one when there are no triggers, and the other when filter yields no matches.~~

![Screenshot_2020-06-02_13-48-10](https://user-images.githubusercontent.com/3845764/83557701-b502b980-a4d7-11ea-9066-dff01c974eb6.png)
![Screenshot_2020-06-02_13-47-50](https://user-images.githubusercontent.com/3845764/83557705-b633e680-a4d7-11ea-9426-d83a8113c3df.png)


Depends on #157 
Depends on https://github.com/RedHatInsights/policies-ui-backend/pull/118