### PR TITLE
POL-285 Relax expression to turn script's src also

### DIFF
--- a/.github/scripts/commands.sh
+++ b/.github/scripts/commands.sh
@@ -3,9 +3,9 @@
 TARGET="${TARGET:-dist/index.html}"
 
 function ensure_beta {
-  sed -i 's/include src=\"\/apps/include src=\"\/beta\/apps/g' "${TARGET}"
+  sed -i 's/src=\"\/apps/src=\"\/beta\/apps/g' "${TARGET}"
 }
 
 function ensure_stable {
-  sed -i 's/include src=\"\/beta\/apps/include src=\"\/apps/g' "${TARGET}"
+  sed -i 's/src=\"\/beta\/apps/src=\"\/apps/g' "${TARGET}"
 }


### PR DESCRIPTION
It wasn't transforming the `<script type="text/javascript" src="/beta/apps/policies/js/vendor.js"></script>` into `<script type="text/javascript" src="/apps/policies/js/vendor.js"></script>`

Tested locally by doing:
1. `yarn build:prod`
2. Including commands `source .github/scripts/commands.sh`
3. `ensure_beta`
4. Inspecting contents of `dist/index.html`, all `src` there should start with `/beta/apps`
5. `ensure_stable`
4. Inspecting contents of `dist/index.html`, all `src` there should start with `/apps`

On ci, testing by inspecting the source code the index for stable [1] and beta [2].

For beta it should have:
1. `<base href="/beta/"/>`
2. `src="/beta/apps/policies/js/vendor.js"`
3. `src="/beta/apps/policies/js/App.js"`

For stable it should have:
1. `<base href="/"/>`
2. `src="/apps/policies/js/vendor.js"`
3. `src="/apps/policies/js/App.js"`

[1] view-source:https://ci.cloud.redhat.com/insights/policies/list
[2] view-source:https://ci.cloud.redhat.com/beta/insights/policies/list