### PR TITLE
POL-288 Remove sorting on last triggered column

### DIFF
--- a/src/components/Policy/Table/PolicyTable.tsx
+++ b/src/components/Policy/Table/PolicyTable.tsx
@@ -177,7 +177,7 @@ export const PolicyTable: React.FunctionComponent<PolicyTableProps> = (props) =>
             },
             is_enabled: {
                 title: Messages.tables.policy.columns.lastTriggered,
-                transforms: transformSortable,
+                transforms: [ ],
                 column: 'is_enabled'
             }
         };


### PR DESCRIPTION
We have no way to sort by last triggered column, it was sorting by isEnabled.
Since its confusing (hence the bug), we can remove the ability to sort by that field (we already have the filtering) until we can actually sort by that column.

Before:
![Screenshot_2020-06-09_11-58-07](https://user-images.githubusercontent.com/3845764/84177448-7ffee580-aa48-11ea-88b8-42c10de9baf8.png)


After:
![Screenshot_2020-06-09_11-54-21](https://user-images.githubusercontent.com/3845764/84177143-141c7d00-aa48-11ea-9fca-84745795822a.png)
