### PR TITLE
Adds error boundary to avoid blank pages on error

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { RouteProps, Route, Switch, Redirect } from 'react-router';
 
+import { ErrorPage } from './pages/Error/Page';
 import ListPage from './pages/ListPage/ListPage';
 import { PolicyDetail } from './pages/PolicyDetail/PolicyDetail';
 
@@ -43,7 +44,11 @@ const InsightsRoute: React.FunctionComponent<InsightsRouteProps> = (props: Insig
     root.classList.add(`page__${rootClass}`, 'pf-c-page__main');
     root.setAttribute('role', 'main');
 
-    return (<Route { ...rest }/>);
+    return (
+        <ErrorPage>
+            <Route { ...rest }/>
+        </ErrorPage>
+    );
 };
 
 type RoutesProps = {};

--- a/src/pages/Error/Page.tsx
+++ b/src/pages/Error/Page.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { Messages } from '../../properties/Messages';
+import { EmptyStateSection } from '../../components/Policy/EmptyState/Section';
+import { ErrorCircleOIcon } from '@patternfly/react-icons';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { linkTo } from '../../Routes';
+import { Expandable, Text } from '@patternfly/react-core';
+import { join } from '../../utils/ComponentUtils';
+import { style } from 'typestyle';
+import { GlobalBackgroundColorDark300 } from '../../utils/PFColors';
+import { Spacer } from '../../utils/Spacer';
+
+type ErrorPageProps = RouteComponentProps<any>;
+
+interface ErrorPageState {
+    hasError: boolean;
+    error?: any;
+}
+
+interface ErrorStackProps {
+    error: any;
+}
+
+const errorClass = style({
+    fontFamily: 'monospace',
+    fontSize: '14px',
+    fontStyle: 'default',
+    textAlign: 'left',
+    backgroundColor: 'white',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: GlobalBackgroundColorDark300,
+    padding: Spacer.SM
+});
+
+const ErrorStack: React.FunctionComponent<ErrorStackProps> = (props) => {
+    const { error } = props;
+
+    if (error.stack) {
+        return (
+            <Text className={ errorClass } component="blockquote">
+                { join(error.stack.split('\n'), 'br') }
+            </Text>
+        );
+    }
+
+    if (error.name && error.message) {
+        return (
+            <>
+                <Text component="h6">
+                    { error.name }
+                </Text>
+                <Text className={ errorClass } component="blockquote">
+                    { error.message }
+                </Text>
+            </>
+        );
+    }
+
+    return (
+        <Text className={ errorClass } component="blockquote">
+            { error.toString() }
+        </Text>
+    );
+};
+
+// As of time of writing, React only supports error boundaries in class components
+class ErrorPageInternal extends React.Component<ErrorPageProps, ErrorPageState> {
+    constructor(props: Readonly<ErrorPageProps>) {
+        super(props);
+        this.state = {
+            hasError: false
+        };
+    }
+
+    static getDerivedStateFromError(error): ErrorPageState {
+        return { hasError: true, error };
+    }
+
+    goToListPage = () => {
+        this.setState({
+            error: undefined,
+            hasError: false
+        });
+        this.props.history.push(linkTo.listPage());
+    };
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <>
+                    <PageHeader>
+                        <PageHeaderTitle title={ Messages.pages.error.title }/>
+                    </PageHeader>
+                    <Main>
+                        <EmptyStateSection
+                            icon={ ErrorCircleOIcon }
+                            title={ Messages.pages.error.emptyState.title }
+                            content={ <>
+                                { Messages.pages.error.emptyState.content }
+                                { this.state.error && (
+                                    <Expandable toggleText={ Messages.pages.error.emptyState.showDetails }>
+                                        <ErrorStack error={ this.state.error } />
+                                    </Expandable>
+                                )}
+                            </> }
+                            action={ this.goToListPage }
+                            actionLabel={ Messages.pages.error.emptyState.actions.goToIndex }
+                        />
+                    </Main>
+                </>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export const ErrorPage = withRouter(ErrorPageInternal);

--- a/src/pages/Error/__tests__/Page.test.tsx
+++ b/src/pages/Error/__tests__/Page.test.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ErrorPage } from '../Page';
+import { getRouterWrapper } from '../../../../test/RouterWrapper';
+import { linkTo } from '../../../Routes';
+
+jest.mock('@redhat-cloud-services/frontend-components', () => {
+
+    const Children: React.FunctionComponent = (props) => {
+        return <span>{ props.children }</span>;
+    };
+
+    const Title: React.FunctionComponent<any> = (props) => {
+        return <span>{ props.title }</span>;
+    };
+
+    return {
+        Main: Children,
+        PageHeader: Children,
+        PageHeaderTitle: Title
+    };
+});
+
+describe('src/pages/Error/Page', () => {
+
+    let mockConsole;
+
+    beforeEach(() => {
+        mockConsole = jest.spyOn(console, 'error');
+        mockConsole.mockImplementation(() => '');
+    });
+
+    afterEach(() => {
+        mockConsole.mockRestore();
+    });
+
+    it('Renders content when there is no error', () => {
+        const { RouterWrapper } = getRouterWrapper('/');
+        render(<ErrorPage>
+            <div>hello world</div>
+        </ErrorPage>, {
+            wrapper: RouterWrapper
+        });
+
+        expect(screen.getByText('hello world')).toBeVisible();
+    });
+
+    it('Renders error screen when there is an error', () => {
+        const { RouterWrapper } = getRouterWrapper('/');
+        const Surprise = () => {
+            throw new Error('surprise');
+        };
+
+        render(<ErrorPage>
+            <Surprise/>
+        </ErrorPage>, {
+            wrapper: RouterWrapper
+        });
+
+        expect(screen.getByText(/Unhandled error/i)).toBeVisible();
+    });
+
+    it('Details are hidden', () => {
+        const { RouterWrapper } = getRouterWrapper('/');
+        const Surprise = () => {
+            throw new Error('surprise');
+        };
+
+        render(<ErrorPage>
+            <Surprise/>
+        </ErrorPage>, {
+            wrapper: RouterWrapper
+        });
+
+        expect(screen.getByText(/surprise/i)).not.toBeVisible();
+    });
+
+    it('Shows when show details is clicked', () => {
+        const { RouterWrapper } = getRouterWrapper('/');
+        const Surprise = () => {
+            throw new Error('surprise');
+        };
+
+        render(<ErrorPage>
+            <Surprise/>
+        </ErrorPage>, {
+            wrapper: RouterWrapper
+        });
+
+        userEvent.click(screen.getByText(/show details/i));
+        expect(screen.getByText(/surprise/i)).toBeVisible();
+    });
+
+    it('Goes to list page when clicking the button', () => {
+        const { RouterWrapper, data } = getRouterWrapper('/');
+        const Surprise = () => {
+            throw new Error('surprise');
+        };
+
+        render(<ErrorPage>
+            <Surprise/>
+        </ErrorPage>, {
+            wrapper: RouterWrapper
+        });
+
+        userEvent.click(screen.getByRole('button', {
+            name: /policy/i
+        }));
+        expect(data.location.pathname).toEqual(linkTo.listPage());
+    });
+});

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -20,7 +20,7 @@ const MutableMessages = {
             title: 'Policies',
             emptyState: {
                 title: 'Unhandled error',
-                content: 'There was a problem trying to process you request.',
+                content: 'There was a problem trying to process your request.',
                 showDetails: 'Show details',
                 actions: {
                     goToIndex: 'Go to Policy list'

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -16,6 +16,17 @@ const MutableMessages = {
                 content: 'Contact your organization administrator(s) for more information.'
             }
         },
+        error: {
+            title: 'Policies',
+            emptyState: {
+                title: 'Unhandled error',
+                content: 'There was a problem trying to process you request.',
+                showDetails: 'Show details',
+                actions: {
+                    goToIndex: 'Go to Policy list'
+                }
+            }
+        },
         listPage: {
             title: 'Policies',
             emailOptIn: 'One or more of your policies have an email alert. To receive these emails, opt in to email alerts.',

--- a/src/utils/ComponentUtils.tsx
+++ b/src/utils/ComponentUtils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-type JoinType = (elements: Array<React.ReactNode>, GlueComponent: React.ComponentType) => Array<React.ReactNode>;
+type JoinType = (elements: Array<React.ReactNode>, GlueComponent: React.ElementType) => Array<React.ReactNode>;
 
 export const join: JoinType = (elements, GlueComponent) => {
     const initialValue: Array<React.ReactNode> = [];

--- a/test/AppWrapper.tsx
+++ b/test/AppWrapper.tsx
@@ -7,7 +7,6 @@ import { Provider } from 'react-redux';
 import fetchMock = require('fetch-mock');
 import { MemoryRouterProps, useLocation } from 'react-router';
 import { AppContext } from '../src/app/AppContext';
-import { linkTo } from '../src/Routes';
 
 let setup = false;
 let client;


### PR DESCRIPTION

I manually added some errors for this gif, but we have seen events when nothing is rendered in the app (only insights chrome is show)
![Peek 2020-06-16 14-39](https://user-images.githubusercontent.com/3845764/84824813-1f425080-afe6-11ea-92b1-c89236c5a9d1.gif)
