### PR TITLE
Switch webhook to notifications

### DIFF
--- a/src/components/Policy/ActionForm/ActionForm.tsx
+++ b/src/components/Policy/ActionForm/ActionForm.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 import { ActionType } from '../../../types/Policy/Actions';
 import { ActionFormProps } from './ActionFormProps';
 import { ActionEmailForm } from './ActionEmailForm';
-import { ActionWebhookForm } from './ActionWebhookForm';
+import { ActionNotificationForm } from './ActionNotificationForm';
 
 export const ActionForm = (props: ActionFormProps) => {
     const actionType = props.action?.type || undefined;
     switch (actionType) {
         case ActionType.EMAIL:
             return <ActionEmailForm { ...props }/>;
-        case ActionType.WEBHOOK:
-            return <ActionWebhookForm { ...props }/>;
+        case ActionType.NOTIFICATION:
+            return <ActionNotificationForm { ...props }/>;
         case undefined:
             return null;
         default:

--- a/src/components/Policy/ActionForm/ActionNotificationForm.tsx
+++ b/src/components/Policy/ActionForm/ActionNotificationForm.tsx
@@ -20,18 +20,18 @@ const TextWithLink: React.FunctionComponent<TextWithLinkProps> = (props) => {
     );
 };
 
-export const ActionWebhookForm: React.FunctionComponent<ActionFormProps> = (props: ActionFormProps) => {
+export const ActionNotificationForm: React.FunctionComponent<ActionFormProps> = (props: ActionFormProps) => {
 
-    const hooksUrl = React.useMemo(() => Config.pages.hooks(), []);
+    const hooksUrl = React.useMemo(() => Config.pages.notifications(), []);
 
     return (
         <div { ...getOuiaProps('Policy/Action/Hook', props) }>
             <TextWithLink
-                { ...Messages.components.actionWebhookForm.paragraph1 }
+                { ...Messages.components.actionNotificationForm.paragraph1 }
                 url={ hooksUrl }
             />
             <TextWithLink
-                { ...Messages.components.actionWebhookForm.paragraph2 }
+                { ...Messages.components.actionNotificationForm.paragraph2 }
                 url={ hooksUrl }
             />
         </div>

--- a/src/components/Policy/ActionIcons.tsx
+++ b/src/components/Policy/ActionIcons.tsx
@@ -15,7 +15,7 @@ type ActionIconProps = {
 export const ActionIcon: React.FunctionComponent<ActionIconProps> = (props) => {
     const { actionType, ...iconProps } = props;
     switch (actionType) {
-        case ActionType.WEBHOOK:
+        case ActionType.NOTIFICATION:
             return <ActionWebhookIcon { ...iconProps }/>;
         case ActionType.EMAIL:
             return <ActionEmailIcon { ...iconProps }/>;

--- a/src/components/Policy/ActionsForm.tsx
+++ b/src/components/Policy/ActionsForm.tsx
@@ -45,8 +45,8 @@ const titleForActionType = (actionType: ActionType) => {
     switch (actionType) {
         case ActionType.EMAIL:
             return 'Send email';
-        case ActionType.WEBHOOK:
-            return 'Send to hook';
+        case ActionType.NOTIFICATION:
+            return 'Send to notification';
         default:
             assertNever(actionType);
     }

--- a/src/components/Policy/AddTriggersDropdown.tsx
+++ b/src/components/Policy/AddTriggersDropdown.tsx
@@ -29,7 +29,7 @@ export const AddTriggersDropdown: React.FunctionComponent<AddTriggersDropdownPro
 
     const items = Object.values(ActionType)
     .filter(actionType => {
-        return !isProd || actionType !== ActionType.WEBHOOK;
+        return !isProd || actionType !== ActionType.NOTIFICATION;
     })
     .map(type =>
         <DropdownItem

--- a/src/components/Policy/Table/ActionsCell.tsx
+++ b/src/components/Policy/Table/ActionsCell.tsx
@@ -52,7 +52,7 @@ export const ActionsCell: React.FunctionComponent<ActionsCellProps> = (props) =>
             case ActionType.EMAIL:
                 element = <ActionEmailIconTooltip/>;
                 break;
-            case ActionType.WEBHOOK:
+            case ActionType.NOTIFICATION:
                 element = <ActionWebhookIconTooltip/>;
                 break;
             default:

--- a/src/components/Policy/Table/ExpandedContent/Actions.tsx
+++ b/src/components/Policy/Table/ExpandedContent/Actions.tsx
@@ -69,10 +69,10 @@ const getActions = (actions: Action[]) => {
                     </React.Fragment>
                 ));
                 break;
-            case ActionType.WEBHOOK:
+            case ActionType.NOTIFICATION:
                 elements.push((
                     <React.Fragment key={ index }>
-                        <ActionWrapper title="Send to Hook" icon={ ActionWebhookIcon }/>
+                        <ActionWrapper title="Send to notification" icon={ ActionWebhookIcon }/>
                     </React.Fragment>
                 ));
                 break;

--- a/src/components/Policy/__tests__/AddTriggersDropdown.test.tsx
+++ b/src/components/Policy/__tests__/AddTriggersDropdown.test.tsx
@@ -34,7 +34,7 @@ describe('src/components/Policy/AddTriggersDropdown', () => {
             );
         });
 
-        expect(element.queryByText(/Webhook/i)).toBeFalsy();
+        expect(element.queryByText(/Notification/i)).toBeFalsy();
         expect(element.queryByText(/Email/i)).toBeTruthy();
     });
 
@@ -55,7 +55,7 @@ describe('src/components/Policy/AddTriggersDropdown', () => {
             );
         });
 
-        expect(element.queryByText(/Webhook/i)).toBeTruthy();
+        expect(element.queryByText(/Notification/i)).toBeTruthy();
         expect(element.queryByText(/Email/i)).toBeTruthy();
     });
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -20,7 +20,7 @@ const Config = {
     },
     pages: {
         emailPreferences: () => localUrl('/user-preferences/email', getInsights().chrome.isBeta()),
-        hooks: () => localUrl('/settings/hooks', getInsights().chrome.isBeta()),
+        notifications: () => localUrl('/settings/notifications', getInsights().chrome.isBeta()),
         // eslint-disable-next-line max-len
         factsDocumentation: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2020-04/html/monitoring_and_reacting_to_configuration_changes_using_policies/appendix-policies#facts-and-functions'
     }

--- a/src/generated/ActionCreators.ts
+++ b/src/generated/ActionCreators.ts
@@ -276,13 +276,3 @@ export const actionPutPoliciesByPolicyId = (params: UsePutPoliciesByPolicyIdPara
     .build();
 };
 
-export const actionGetStatus = (): Action => {
-    const path = '/api/policies/v1.0/status';
-
-    const query = {} as Record<string, any>;
-
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .build();
-};
-

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -3,7 +3,7 @@ import { ActionType } from '../types/Policy/Actions';
 
 const actionTypeToText: Record<ActionType, string> = {
     [ActionType.EMAIL]: 'Email',
-    [ActionType.WEBHOOK]: 'Webhook'
+    [ActionType.NOTIFICATION]: 'Notification'
 };
 
 //Capture some strings we reuse. Possibly use in i18n later?
@@ -85,16 +85,16 @@ const MutableMessages = {
             never: 'Never',
             ago: 'ago'
         },
-        actionWebhookForm: {
+        actionNotificationForm: {
             paragraph1: {
-                head: 'This action sends a post to all webhooks which have been activated for policies in the ',
-                link: 'application settings.',
+                head: 'This action sends a request notification to process the message as configured in ',
+                link: 'notification settings.',
                 tail: ''
             },
             paragraph2: {
-                head: 'To activate a webhook for policies, open the webhook in the ',
-                link: 'application settings',
-                tail: ' and select your preference for sending a post under "Policies".'
+                head: 'To configure it for policies, open the notification in the ',
+                link: 'notification settings',
+                tail: ' and select your preference for sending under "Policies / All".'
             }
         }
     },

--- a/src/schemas/CreatePolicy/Actions/ActionNotificationSchema.ts
+++ b/src/schemas/CreatePolicy/Actions/ActionNotificationSchema.ts
@@ -1,0 +1,6 @@
+import * as Yup from 'yup';
+import { ActionType } from '../../../types/Policy/Actions';
+
+export const ActionNotificationSchema = Yup.object().shape({
+    type: Yup.mixed<ActionType.NOTIFICATION>().oneOf([ ActionType.NOTIFICATION ]).required()
+});

--- a/src/schemas/CreatePolicy/Actions/ActionWebhookSchema.ts
+++ b/src/schemas/CreatePolicy/Actions/ActionWebhookSchema.ts
@@ -1,6 +1,0 @@
-import * as Yup from 'yup';
-import { ActionType } from '../../../types/Policy/Actions';
-
-export const ActionWebhookSchema = Yup.object().shape({
-    type: Yup.mixed<ActionType.WEBHOOK>().oneOf([ ActionType.WEBHOOK ]).required()
-});

--- a/src/schemas/CreatePolicy/Actions/__tests__/ActionEmailSchema.test.ts
+++ b/src/schemas/CreatePolicy/Actions/__tests__/ActionEmailSchema.test.ts
@@ -18,9 +18,9 @@ describe('src/schemas/CreatePolicy/Actions/ActionEmailSchema', () => {
         })).toBeFalsy();
     });
 
-    it('should fail if type is ActionType.Webhook', () => {
+    it('should fail if type is ActionType.Notification', () => {
         expect(ActionEmailSchema.isValidSync({
-            type: ActionType.WEBHOOK
+            type: ActionType.NOTIFICATION
         })).toBeFalsy();
     });
 

--- a/src/schemas/CreatePolicy/Actions/__tests__/ActionWebhookSchema.test.ts
+++ b/src/schemas/CreatePolicy/Actions/__tests__/ActionWebhookSchema.test.ts
@@ -1,32 +1,32 @@
-import { ActionWebhookSchema } from '../ActionWebhookSchema';
+import { ActionNotificationSchema } from '../ActionNotificationSchema';
 import { ActionType } from '../../../../types/Policy/Actions';
 
-describe('src/schemas/CreatePolicy/Actions/ActionWebhookSchema', () => {
+describe('src/schemas/CreatePolicy/Actions/ActionNotificationSchema', () => {
     it('should fail when type is undefined', () => {
-        expect(ActionWebhookSchema.isValidSync({
+        expect(ActionNotificationSchema.isValidSync({
             type: undefined
         })).toBeFalsy();
     });
 
     it('should fail when type is omitted', () => {
-        expect(ActionWebhookSchema.isValidSync({})).toBeFalsy();
+        expect(ActionNotificationSchema.isValidSync({})).toBeFalsy();
     });
 
     it('should fail if type is not an ActionType', () => {
-        expect(ActionWebhookSchema.isValidSync({
+        expect(ActionNotificationSchema.isValidSync({
             type: 'foo'
         })).toBeFalsy();
     });
 
     it('should fail if type is ActionType.EMAIL', () => {
-        expect(ActionWebhookSchema.isValidSync({
+        expect(ActionNotificationSchema.isValidSync({
             type: ActionType.EMAIL
         })).toBeFalsy();
     });
 
-    it('should succeed if using ActionType.WEBHOOK', () => {
-        expect(ActionWebhookSchema.isValidSync({
-            type: ActionType.WEBHOOK
+    it('should succeed if using ActionType.NOTIFICATION', () => {
+        expect(ActionNotificationSchema.isValidSync({
+            type: ActionType.NOTIFICATION
         })).toBeTruthy();
     });
 });

--- a/src/schemas/CreatePolicy/Actions/index.ts
+++ b/src/schemas/CreatePolicy/Actions/index.ts
@@ -1,3 +1,3 @@
 export { ActionSchema } from './ActionSchema';
 export { ActionEmailSchema } from './ActionEmailSchema';
-export { ActionWebhookSchema } from './ActionWebhookSchema';
+export { ActionNotificationSchema } from './ActionNotificationSchema';

--- a/src/schemas/CreatePolicy/PolicySchema.ts
+++ b/src/schemas/CreatePolicy/PolicySchema.ts
@@ -2,7 +2,7 @@ import { Action, ActionType } from '../../types/Policy/Actions';
 import * as Yup from 'yup';
 import { ValidationError } from 'yup';
 import { maxPolicyNameLength } from '../../types/Policy/Policy';
-import { ActionEmailSchema, ActionSchema, ActionWebhookSchema } from './Actions';
+import { ActionEmailSchema, ActionSchema, ActionNotificationSchema } from './Actions';
 import { assertNever } from '@redhat-cloud-services/insights-common-typescript';
 import { isAction } from '../../types/Policy/Actions/Action';
 
@@ -12,8 +12,8 @@ const ActionSchemaSelector = (action: Action | any): Yup.Schema<any> => {
         switch (type) {
             case ActionType.EMAIL:
                 return ActionEmailSchema;
-            case ActionType.WEBHOOK:
-                return ActionWebhookSchema;
+            case ActionType.NOTIFICATION:
+                return ActionNotificationSchema;
             default:
                 assertNever(type);
         }
@@ -67,7 +67,7 @@ export const PolicyFormDetails = Yup.object().shape({
 export const PolicyFormActions = Yup.object().shape({
     actions: Yup.array(Yup.lazy(ActionSchemaSelector))
     .test(...oneActionOf(ActionType.EMAIL, 'Email', 'email'))
-    .test(...oneActionOf(ActionType.WEBHOOK, 'Hook', 'webhook'))
+    .test(...oneActionOf(ActionType.NOTIFICATION, 'Hook', 'notification'))
 });
 
 export const PolicyFormConditions = Yup.object().shape({

--- a/src/schemas/CreatePolicy/__tests__/PolicySchema.test.ts
+++ b/src/schemas/CreatePolicy/__tests__/PolicySchema.test.ts
@@ -78,7 +78,7 @@ describe('src/schemas/CreatePolicy/PolicySchema', () => {
                         type: ActionType.EMAIL
                     },
                     {
-                        type: ActionType.WEBHOOK
+                        type: ActionType.NOTIFICATION
                     }
                 ]
             })).toBeTruthy();
@@ -91,7 +91,7 @@ describe('src/schemas/CreatePolicy/PolicySchema', () => {
                         type: ActionType.EMAIL
                     },
                     {
-                        type: ActionType.WEBHOOK
+                        type: ActionType.NOTIFICATION
                     },
                     {
                         type: ActionType.EMAIL
@@ -100,17 +100,17 @@ describe('src/schemas/CreatePolicy/PolicySchema', () => {
             })).toBeFalsy();
         });
 
-        it('Only allows one webhook', () => {
+        it('Only allows one notification', () => {
             expect(PolicyFormActions.isValidSync({
                 actions: [
                     {
                         type: ActionType.EMAIL
                     },
                     {
-                        type: ActionType.WEBHOOK
+                        type: ActionType.NOTIFICATION
                     },
                     {
-                        type: ActionType.WEBHOOK
+                        type: ActionType.NOTIFICATION
                     }
                 ]
             })).toBeFalsy();

--- a/src/types/Policy/Actions/Action.ts
+++ b/src/types/Policy/Actions/Action.ts
@@ -1,17 +1,17 @@
 import { ActionEmail } from './ActionEmail';
-import { ActionWebhook } from './ActionWebhook';
+import { ActionNotification } from './ActionNotification';
 import { ActionType } from './ActionType';
 
-export type Action = ActionEmail | ActionWebhook;
+export type Action = ActionEmail | ActionNotification;
 
 export const isActionEmail = (action: Action): action is ActionEmail => {
     return action.type === ActionType.EMAIL;
 };
 
-export const isActionWebhook = (action: Action): action is ActionWebhook => {
-    return action.type === ActionType.WEBHOOK;
+export const isActionNotification = (action: Action): action is ActionNotification => {
+    return action.type === ActionType.NOTIFICATION;
 };
 
 export const isAction = (maybeAction: any): maybeAction is Action => {
-    return isActionEmail(maybeAction) || isActionWebhook(maybeAction);
+    return isActionEmail(maybeAction) || isActionNotification(maybeAction);
 };

--- a/src/types/Policy/Actions/ActionNotification.ts
+++ b/src/types/Policy/Actions/ActionNotification.ts
@@ -1,0 +1,5 @@
+import { ActionType } from './ActionType';
+
+export interface ActionNotification {
+    type: ActionType.NOTIFICATION;
+}

--- a/src/types/Policy/Actions/ActionType.ts
+++ b/src/types/Policy/Actions/ActionType.ts
@@ -1,5 +1,5 @@
 export enum ActionType {
     EMAIL = 'email',
-    WEBHOOK = 'webhook'
+    NOTIFICATION = 'notification'
 }
 

--- a/src/types/Policy/Actions/ActionWebhook.ts
+++ b/src/types/Policy/Actions/ActionWebhook.ts
@@ -1,5 +1,0 @@
-import { ActionType } from './ActionType';
-
-export interface ActionWebhook {
-    type: ActionType.WEBHOOK;
-}

--- a/src/types/Policy/Actions/__tests__/Action.test.ts
+++ b/src/types/Policy/Actions/__tests__/Action.test.ts
@@ -1,7 +1,7 @@
 import { ActionEmail } from '../ActionEmail';
 import { ActionType } from '../ActionType';
-import { isAction, isActionEmail, isActionWebhook } from '../Action';
-import { ActionWebhook } from '../ActionWebhook';
+import { isAction, isActionEmail, isActionNotification } from '../Action';
+import { ActionNotification } from '../ActionNotification';
 
 describe('src/types/Policy/Actions', () => {
 
@@ -12,9 +12,9 @@ describe('src/types/Policy/Actions', () => {
         expect(isAction(action)).toBe(true);
     });
 
-    it('isAction returns true for ActionWebhook', () => {
-        const action: ActionWebhook = {
-            type: ActionType.WEBHOOK
+    it('isAction returns true for ActionNotification', () => {
+        const action: ActionNotification = {
+            type: ActionType.NOTIFICATION
         };
         expect(isAction(action)).toBe(true);
     });
@@ -42,23 +42,23 @@ describe('src/types/Policy/Actions', () => {
         expect(isActionEmail(action)).toBe(true);
     });
 
-    it('isActionWebhook returns false for ActionEmail', () => {
+    it('isActionNotification returns false for ActionEmail', () => {
         const action: ActionEmail = {
             type: ActionType.EMAIL
         };
-        expect(isActionWebhook(action)).toBe(false);
+        expect(isActionNotification(action)).toBe(false);
     });
 
-    it('isActionWebhook returns true for ActionWebhook', () => {
-        const action: ActionWebhook = {
-            type: ActionType.WEBHOOK
+    it('isActionNotification returns true for ActionNotification', () => {
+        const action: ActionNotification = {
+            type: ActionType.NOTIFICATION
         };
-        expect(isActionWebhook(action)).toBe(true);
+        expect(isActionNotification(action)).toBe(true);
     });
 
-    it('isActionEmail returns false for ActionWebhook', () => {
-        const action: ActionWebhook = {
-            type: ActionType.WEBHOOK
+    it('isActionEmail returns false for ActionNotification', () => {
+        const action: ActionNotification = {
+            type: ActionType.NOTIFICATION
         };
         expect(isActionEmail(action)).toBe(false);
     });

--- a/src/types/Policy/Actions/index.ts
+++ b/src/types/Policy/Actions/index.ts
@@ -1,4 +1,4 @@
 export { Action } from './Action';
 export { ActionType } from './ActionType';
 export { ActionEmail } from './ActionEmail';
-export { ActionWebhook } from './ActionWebhook';
+export { ActionNotification } from './ActionNotification';

--- a/src/types/adapters/PolicyAdapter.ts
+++ b/src/types/adapters/PolicyAdapter.ts
@@ -22,7 +22,7 @@ export const toServerAction = (actions: DeepPartial<Action[]>): string => {
         const encodedAction = `${action.type}`;
 
         switch (action.type) {
-            case ActionType.WEBHOOK:
+            case ActionType.NOTIFICATION:
                 break;
             case ActionType.EMAIL:
                 break;
@@ -42,10 +42,15 @@ export const fromServerActions = (actions?: string): Action[] => {
     const policyAction: Action[] = [];
     for (const action of actions.split(';')) {
         const [ actionType ] = action.split(' ', 2);
+        // Just in case the server still has the webhook, we will just skip it.
+        if (actionType === 'webhook') {
+            continue;
+        }
+
         switch (actionType) {
-            case ActionType.WEBHOOK:
+            case ActionType.NOTIFICATION:
                 policyAction.push({
-                    type: ActionType.WEBHOOK
+                    type: ActionType.NOTIFICATION
                 });
                 break;
             case ActionType.EMAIL:

--- a/src/types/adapters/__tests__/PolicyAdapter.test.ts
+++ b/src/types/adapters/__tests__/PolicyAdapter.test.ts
@@ -24,7 +24,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: 'email;webhook',
+            actions: 'email;notification',
             mtime: '2014-01-01T23:28:56.782Z',
             ctime: '2013-01-01T23:28:56.782Z',
             lastTriggered: 77897987000
@@ -40,7 +40,41 @@ describe('src/utils/PolicyAdapter', () => {
                     type: ActionType.EMAIL
                 },
                 {
-                    type: ActionType.WEBHOOK
+                    type: ActionType.NOTIFICATION
+                }
+            ],
+            mtime: new Date('2014-01-01T23:28:56.782Z'),
+            ctime: new Date('2013-01-01T23:28:56.782Z'),
+            lastTriggered: new Date('1972-06-20T14:19:47.000Z')
+        };
+
+        expect(toPolicy(sp)).toEqual(policy);
+    });
+
+    it('toPolicy silently ignores webhook', () => {
+        const sp: ServerPolicyResponse = {
+            id: '5151-5151',
+            name: 'foo policy',
+            description: 'foo description',
+            isEnabled: true,
+            conditions: '1 == 2',
+            actions: 'email;notification;webhook',
+            mtime: '2014-01-01T23:28:56.782Z',
+            ctime: '2013-01-01T23:28:56.782Z',
+            lastTriggered: 77897987000
+        };
+        const policy: Policy = {
+            id: '5151-5151',
+            name: 'foo policy',
+            description: 'foo description',
+            isEnabled: true,
+            conditions: '1 == 2',
+            actions: [
+                {
+                    type: ActionType.EMAIL
+                },
+                {
+                    type: ActionType.NOTIFICATION
                 }
             ],
             mtime: new Date('2014-01-01T23:28:56.782Z'),
@@ -71,7 +105,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: 'email;webhook',
+            actions: 'email;notification',
             mtime: '2014-01-01T23:28:56.782Z',
             ctime: '2013-01-01T23:28:56.782Z',
             lastTriggered: 0
@@ -87,7 +121,7 @@ describe('src/utils/PolicyAdapter', () => {
                     type: ActionType.EMAIL
                 },
                 {
-                    type: ActionType.WEBHOOK
+                    type: ActionType.NOTIFICATION
                 }
             ],
             mtime: new Date('2014-01-01T23:28:56.782Z'),
@@ -105,7 +139,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: 'email;webhook',
+            actions: 'email;notification',
             mtime: '2014-01-01T23:28:56.782Z',
             ctime: '2013-01-01T23:28:56.782Z',
             lastTriggered: 1589912060644
@@ -121,7 +155,7 @@ describe('src/utils/PolicyAdapter', () => {
                     type: ActionType.EMAIL
                 },
                 {
-                    type: ActionType.WEBHOOK
+                    type: ActionType.NOTIFICATION
                 }
             ],
             mtime: new Date('2014-01-01T23:28:56.782Z'),
@@ -233,7 +267,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: 'webhook',
+            actions: 'notification',
             mtime: '2014-01-01T23:28:56.782Z',
             ctime: '2013-01-01T23:28:56.782Z',
             lastTriggered: 458906840000
@@ -269,7 +303,7 @@ describe('src/utils/PolicyAdapter', () => {
             conditions: '1 == 2',
             actions: [
                 {
-                    type: ActionType.WEBHOOK
+                    type: ActionType.NOTIFICATION
                 }
             ],
             mtime: new Date('2014-01-01T23:28:56.782Z'),
@@ -319,7 +353,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: [{ type: ActionType.EMAIL }, { type: ActionType.WEBHOOK }],
+            actions: [{ type: ActionType.EMAIL }, { type: ActionType.NOTIFICATION }],
             mtime: new Date('2014-01-01T23:28:56.782Z'),
             ctime: new Date('2013-01-01T23:28:56.782Z'),
             lastTriggered: new Date('2015-01-01T23:28:56.782Z')
@@ -332,7 +366,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: [{ type: ActionType.EMAIL }, { type: ActionType.WEBHOOK }],
+            actions: [{ type: ActionType.EMAIL }, { type: ActionType.NOTIFICATION }],
             ctime: undefined,
             lastTriggered: undefined
         };
@@ -351,7 +385,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: [{ type: ActionType.EMAIL }, { type: ActionType.WEBHOOK }],
+            actions: [{ type: ActionType.EMAIL }, { type: ActionType.NOTIFICATION }],
             mtime: new Date('2014-01-01T23:28:56.782Z'),
             ctime: new Date('2013-01-01T23:28:56.782Z'),
             lastTriggered: new Date('2015-01-01T23:28:56.782Z')
@@ -364,7 +398,7 @@ describe('src/utils/PolicyAdapter', () => {
             description: 'foo description',
             isEnabled: true,
             conditions: '1 == 2',
-            actions: [{ type: ActionType.EMAIL }, { type: ActionType.WEBHOOK }],
+            actions: [{ type: ActionType.EMAIL }, { type: ActionType.NOTIFICATION }],
             ctime: undefined,
             lastTriggered: undefined
         };
@@ -377,7 +411,7 @@ describe('src/utils/PolicyAdapter', () => {
     });
 
     it('fromServerActions parses the actions action', () => {
-        const actions = 'email;email;webhook';
+        const actions = 'email;email;notification';
         expect(fromServerActions(actions)).toEqual([
             {
                 type: ActionType.EMAIL
@@ -386,7 +420,7 @@ describe('src/utils/PolicyAdapter', () => {
                 type: ActionType.EMAIL
             },
             {
-                type: ActionType.WEBHOOK
+                type: ActionType.NOTIFICATION
             }
         ]);
     });
@@ -407,12 +441,12 @@ describe('src/utils/PolicyAdapter', () => {
                 type: ActionType.EMAIL
             },
             {
-                type: ActionType.WEBHOOK
+                type: ActionType.NOTIFICATION
             },
             {
                 type: ActionType.EMAIL
             }
-        ])).toEqual('email;webhook;email');
+        ])).toEqual('email;notification;email');
     });
 
     it('toServerActions yields empty string for unspecified action', () => {

--- a/src/utils/exporters/Policy/__tests__/Csv.test.ts
+++ b/src/utils/exporters/Policy/__tests__/Csv.test.ts
@@ -24,7 +24,7 @@ describe('src/utils/exporters/Policy/Csv', () => {
                 lastTriggered: new Date(2030, 5, 5),
                 actions: [
                     {
-                        type: ActionType.WEBHOOK
+                        type: ActionType.NOTIFICATION
                     },
                     {
                         type: ActionType.EMAIL


### PR DESCRIPTION
 - Does not break if ui-backend still has "webhook", silently ignores it.