### PR TITLE
Show notification action on [ci|qa|stage]-beta but not on prod-beta

### DIFF
--- a/src/components/Policy/AddTriggersDropdown.tsx
+++ b/src/components/Policy/AddTriggersDropdown.tsx
@@ -31,10 +31,7 @@ export const AddTriggersDropdown: React.FunctionComponent<AddTriggersDropdownPro
 
     const hideNotification = !isBeta || isProd;
 
-    const items = Object.values(ActionType)
-    .filter(actionType => {
-        return !hideNotification || actionType !== ActionType.NOTIFICATION;
-    })
+    const items = [ hideNotification ? ActionType.EMAIL : ActionType.NOTIFICATION ]
     .map(type =>
         <DropdownItem
             key={ type }

--- a/src/components/Policy/AddTriggersDropdown.tsx
+++ b/src/components/Policy/AddTriggersDropdown.tsx
@@ -26,11 +26,14 @@ export const AddTriggersDropdown: React.FunctionComponent<AddTriggersDropdownPro
         setOpen(false);
     };
 
+    const isBeta = getInsights().chrome.isBeta();
     const isProd = getInsights().chrome.isProd;
+
+    const hideNotification = !isBeta || isProd;
 
     const items = Object.values(ActionType)
     .filter(actionType => {
-        return !isProd || actionType !== ActionType.NOTIFICATION;
+        return !hideNotification || actionType !== ActionType.NOTIFICATION;
     })
     .map(type =>
         <DropdownItem

--- a/src/components/Policy/__tests__/AddTriggersDropdown.test.tsx
+++ b/src/components/Policy/__tests__/AddTriggersDropdown.test.tsx
@@ -6,9 +6,10 @@ import { AddTriggersDropdown } from '../AddTriggersDropdown';
 
 describe('src/components/Policy/AddTriggersDropdown', () => {
 
-    const mockInsightsIsProd = (isProd: boolean) => {
+    const mockInsightsIsStableAndIsProd = (isStable: boolean, isProd: boolean) => {
         (global as any).insights = {
             chrome: {
+                isBeta: () => !isStable,
                 isProd
             }
         };
@@ -16,10 +17,10 @@ describe('src/components/Policy/AddTriggersDropdown', () => {
 
     beforeEach(() => {
         (global as any).insights = undefined;
-        mockInsightsIsProd(true);
+        mockInsightsIsStableAndIsProd(true, true);
     });
 
-    it('should show email in prod', async () => {
+    it('should show only email in stable & prod', async () => {
         const element = render(<AddTriggersDropdown
             isTypeEnabled={ jest.fn(() => true) }
             onTypeSelected={ jest.fn() }
@@ -39,8 +40,50 @@ describe('src/components/Policy/AddTriggersDropdown', () => {
         expect(element.queryByText(/Email/i)).toBeTruthy();
     });
 
-    it('should show email and webhook in non prod', async () => {
-        mockInsightsIsProd(false);
+    it('should show only email in beta & prod', async () => {
+        mockInsightsIsStableAndIsProd(false, true);
+        const element = render(<AddTriggersDropdown
+            isTypeEnabled={ jest.fn(() => true) }
+            onTypeSelected={ jest.fn() }
+        />);
+
+        act(() => {
+            fireEvent(
+                getByText(element.container, 'Add trigger actions'),
+                new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true
+                })
+            );
+        });
+
+        expect(element.queryByText(/Notification/i)).toBeFalsy();
+        expect(element.queryByText(/Email/i)).toBeTruthy();
+    });
+
+    it('should show only email in stable & non-prod', async () => {
+        mockInsightsIsStableAndIsProd(true, false);
+        const element = render(<AddTriggersDropdown
+            isTypeEnabled={ jest.fn(() => true) }
+            onTypeSelected={ jest.fn() }
+        />);
+
+        act(() => {
+            fireEvent(
+                getByText(element.container, 'Add trigger actions'),
+                new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true
+                })
+            );
+        });
+
+        expect(element.queryByText(/Notification/i)).toBeFalsy();
+        expect(element.queryByText(/Email/i)).toBeTruthy();
+    });
+
+    it('should show email and notification in beta & non-prod', async () => {
+        mockInsightsIsStableAndIsProd(false, false);
         const element = render(<AddTriggersDropdown
             isTypeEnabled={ jest.fn(() => true) }
             onTypeSelected={ jest.fn() }

--- a/src/components/Policy/__tests__/AddTriggersDropdown.test.tsx
+++ b/src/components/Policy/__tests__/AddTriggersDropdown.test.tsx
@@ -82,7 +82,7 @@ describe('src/components/Policy/AddTriggersDropdown', () => {
         expect(element.queryByText(/Email/i)).toBeTruthy();
     });
 
-    it('should show email and notification in beta & non-prod', async () => {
+    it('should show notification in beta & non-prod', async () => {
         mockInsightsIsStableAndIsProd(false, false);
         const element = render(<AddTriggersDropdown
             isTypeEnabled={ jest.fn(() => true) }
@@ -100,7 +100,7 @@ describe('src/components/Policy/AddTriggersDropdown', () => {
         });
 
         expect(element.queryByText(/Notification/i)).toBeTruthy();
-        expect(element.queryByText(/Email/i)).toBeTruthy();
+        expect(element.queryByText(/Email/i)).toBeFalsy();
     });
 
     it('should disable type if isTypeEnabled returns false', () => {


### PR DESCRIPTION
Updating like this in case we need to push something to prod, when we are ready to push notifications to prod-beta I'll update it.

### [ci|qa|stage]-beta:
![Screenshot_2021-01-15_08-57-44](https://user-images.githubusercontent.com/3845764/104742196-c53a7280-570f-11eb-9ce6-5bb7b6fbad6d.png)



### [ci|qa|stage|prod]-stable & prod-beta
![Screenshot_2021-01-14_14-19-54](https://user-images.githubusercontent.com/3845764/104646200-bf904e80-5675-11eb-9601-322dfd640ff7.png)
