### PR TITLE
Fix lingering history changes after unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/plugin-transform-runtime": "7.6.2",
     "@babel/preset-env": "7.7.7",
     "@babel/preset-react": "7.7.4",
-    "@redhat-cloud-services/frontend-components-config": "4.0.9-beta.1",
+    "@redhat-cloud-services/frontend-components-config": "4.0.12",
     "@testing-library/dom": "7.11.0",
     "@testing-library/jest-dom": "5.5.0",
     "@testing-library/react": "10.0.6",

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -1,4 +1,4 @@
-import { fetchRBAC, getInsights, Rbac, waitForInsights } from '@redhat-cloud-services/insights-common-typescript';
+import { fetchRBAC, Rbac, waitForInsights } from '@redhat-cloud-services/insights-common-typescript';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -20,10 +20,6 @@ export const useApp = (): Omit<AppContext, 'rbac'> & Partial<Pick<AppContext, 'r
                 (insights.chrome as any).hideGlobalFilter();
             }
         });
-        return () => {
-            const insights = getInsights();
-            insights.chrome.on('APP_NAVIGATION', (event: any) => history.push(`/${event.navId}`));
-        };
     }, [ history ]);
 
     useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,10 +1438,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.18.tgz#b34afc5fd2567a50b7658aff004f31b536fd9096"
   integrity sha512-zQfqwKtoz1hDngyiGnF6oHeESDtgNY6C79Db97JxMMuRBV7i+5f6uC/DrYhcqNtqHA7mxrVJg0SM1xnPSAW9lA==
 
-"@redhat-cloud-services/frontend-components-config@4.0.9-beta.1":
-  version "4.0.9-beta.1"
-  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.0.9-beta.1.tgz#e26e1459f01a66262912a49cb4366b3c07dd9ba8"
-  integrity sha512-nwRJyLGSP/NnsY2qYCaFd0dR7C7rLO3W4ND0xIfyxl97j52xKJ1EaYYDmgJJLYum1nEkPmz3grg322ODMaZ0eQ==
+"@redhat-cloud-services/frontend-components-config@4.0.12":
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.0.12.tgz#f72be6ab3f55dded47f0b8e8f0616046b6b5d436"
+  integrity sha512-wa53s3VPwO+liw8vlXFcZzYbHXDnVdc44zviz/TU5nXpwFbP5aFWqc7dzqC0uwp9l8vwkASPRkgG1/OXtLNCow==
   dependencies:
     assert "^2.0.0"
     babel-loader "^8.2.1"


### PR DESCRIPTION
### Changes
- update FEC webpack config: fixes singleton issue with redux
- remove history push after app unmounts
  - the return function from the useApp hooks is called after the app unmounts and it adds a listener on the chrome nav changes
  - the history change mutates the URL of other apps after you navigate to the from policies

cc @josejulio 