### PR TITLE
POL-641: Duplicate Name in Create Policy Wizard

### DIFF
--- a/src/pages/CreatePolicyWizard/CreatePolicyWizard.tsx
+++ b/src/pages/CreatePolicyWizard/CreatePolicyWizard.tsx
@@ -118,7 +118,7 @@ export const CreatePolicyWizard: React.FunctionComponent<CreatePolicyWizardProps
 
             return {
                 created: false,
-                error: `Invalid name (Code: ${res.status})`
+                error: (res.payload?.value as any).msg
             };
         });
     }, [ validateNameParamQuery.query ]);


### PR DESCRIPTION
Draft Status: these changes only change the footer error message to be more descriptive. I believe this ticket also wants to move the error message to be below the associated input similarly to other forms in the application/console dot platform