### PR TITLE
update docs versions for Insights, Console, Cost & Subscriptions

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -1,4 +1,7 @@
-import { getInsights, localUrl } from '@redhat-cloud-services/insights-common-typescript';
+import {
+  getInsights,
+  localUrl,
+} from '@redhat-cloud-services/insights-common-typescript';
 import { DeepReadonly } from 'ts-essentials';
 
 const apiVersion = 'v1.0';
@@ -7,23 +10,29 @@ const apiBaseUrl = `/api/policies/${apiVersion}`;
 export const withBaseUrl = (path: string) => `${apiBaseUrl}${path}`;
 
 const Config = {
-    appId: 'policies',
-    defaultElementsPerPage: 20,
-    apis: {
-        version: apiVersion,
-        urls: {
-            base: apiBaseUrl,
-            userSettings: {
-                email: withBaseUrl('/user-config/preferences')
-            }
-        }
+  appId: 'policies',
+  defaultElementsPerPage: 20,
+  apis: {
+    version: apiVersion,
+    urls: {
+      base: apiBaseUrl,
+      userSettings: {
+        email: withBaseUrl('/user-config/preferences'),
+      },
     },
-    pages: {
-        emailPreferences: () => localUrl('/user-preferences/notifications/insights', getInsights().chrome.isBeta()),
-        notifications: () => localUrl('/settings/notifications/rhel', getInsights().chrome.isBeta()),
-        // eslint-disable-next-line max-len
-        factsDocumentation: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/monitoring_and_reacting_to_configuration_changes_using_policies/assembly-policies-monitoring-appendix-ref-materials#ref-policies-monitoring-appendix-system-facts_policies-monitoring-appendix-ref-materials'
-    }
+  },
+  pages: {
+    emailPreferences: () =>
+      localUrl(
+        '/user-preferences/notifications/insights',
+        getInsights().chrome.isBeta()
+      ),
+    notifications: () =>
+      localUrl('/settings/notifications/rhel', getInsights().chrome.isBeta()),
+    // eslint-disable-next-line max-len
+    factsDocumentation:
+      'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/monitoring_and_reacting_to_configuration_changes_using_policies/assembly-policies-monitoring-appendix-ref-materials#ref-policies-monitoring-appendix-system-facts_policies-monitoring-appendix-ref-materials',
+  },
 };
 
 const ReadonlyConfig: DeepReadonly<typeof Config> = Config;


### PR DESCRIPTION
Where links to Insights, Console, Cost & Subscriptions docs exist, this PR updates the url to the 2023 version

