### PR TITLE
 fix(ZeroState): Update zero state according to updated mocks

### DIFF
--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -194,94 +194,99 @@ const ListPage: React.FunctionComponent<unknown> = () => {
 
     return (
         <>
-            <Helmet>
-                <title>Policies | Red Hat Insights</title>
-            </Helmet>
-            <PageHeader>
-                <PageHeaderTitle title={ Messages.pages.listPage.title } />
-            </PageHeader>
-            { !appContext.userSettings.isSubscribedForNotifications &&
-            policyRows.rows.find(p => p.actions.find(a => a.type === ActionType.NOTIFICATION)) && (
-                <PageSection className={ emailOptinPageClassName }>
-                    <InsightsEmailOptIn
-                        ouiaId="list-email-required"
-                        content={ Messages.pages.listPage.emailOptIn }
-                        insights={ getInsights() }
-                        bundle="rhel"
-                    />
-                </PageSection>
-            )}
-            <Main>
-                { !hasSystems ? (
-                    <AsynComponent
-                        appName="dashboard"
-                        module="./AppZeroState"
-                        scope="dashboard"
-                        ErrorComponent={ <ErrorState /> }
-                        app="Policies"
-                    />
-                ) : getPoliciesQuery.hasPolicies === false ?
-                    (
-                        <ListPageEmptyState
-                            createPolicy={ canWritePolicies ? toolbarActions.createCustomPolicy : undefined }
-                        />
-                    )
-                    : (
-                        <Section>
-                            <PolicyToolbar
-                                ouiaId="main-toolbar"
-                                onCreatePolicy={ canWritePolicies ? toolbarActions.createCustomPolicy : undefined }
-                                onDeletePolicy={ canWritePolicies ? toolbarActions.onDeletePolicies : undefined }
-                                onEnablePolicy={ canWritePolicies ? toolbarActions.onEnablePolicies : undefined }
-                                onDisablePolicy={ canWritePolicies ? toolbarActions.onDisablePolicies : undefined }
-                                onPaginationChanged={ policyPage.changePage }
-                                onPaginationSizeChanged={ policyPage.changeItemsPerPage }
-                                onSelectionChanged={ policyRows.onSelectionChanged }
-                                selectedCount={ policyRows.selectionCount }
-                                page={ policyPage.page.index }
-                                pageCount={ policyRows.rows.length }
-                                perPage={ policyPage.page.size }
-                                showPerPageOptions={ true }
-                                filters={ policyFilters.filters }
-                                setFilters= { policyFilters.setFilters }
-                                clearFilters={ policyFilters.clearFilter }
-                                count={ getPoliciesQueryCount }
-                                onExport={ toolbarActions.onExport }
-                                showBottomPagination={ true }
-                            >
-                                <PolicyTable
-                                    ouiaId="main-table"
-                                    policies={ policyRows.rows }
-                                    onCollapse={ policyRows.onCollapse }
-                                    onSelect={ policyRows.onSelect }
-                                    actionResolver={ tableActionsResolver }
-                                    loading={ isLoading }
-                                    error={ policyTableErrorValue }
-                                    onSort={ sort.onSort }
-                                    sortBy={ sort.sortBy }
-                                    linkToDetailPolicy={ true }
-                                />
-                            </PolicyToolbar>
-                        </Section>
+            {!hasSystems ?
+                <AsynComponent
+                    appName="dashboard"
+                    module="./AppZeroState"
+                    scope="dashboard"
+                    ErrorComponent={ <ErrorState /> }
+                    app="Policies"
+                />
+                :
+                <>
+                    <Helmet>
+                        <title>Policies | Red Hat Insights</title>
+                    </Helmet>
+                    <PageHeader>
+                        <PageHeaderTitle title={ Messages.pages.listPage.title } />
+                    </PageHeader>
+                    { !appContext.userSettings.isSubscribedForNotifications &&
+                        policyRows.rows.find(p => p.actions.find(a => a.type === ActionType.NOTIFICATION)) && (
+                        <PageSection className={ emailOptinPageClassName }>
+                            <InsightsEmailOptIn
+                                ouiaId="list-email-required"
+                                content={ Messages.pages.listPage.emailOptIn }
+                                insights={ getInsights() }
+                                bundle="rhel"
+                            />
+                        </PageSection>
                     )}
-            </Main>
-            { policyWizardState.isOpen && <CreatePolicyWizard
-                isOpen={ policyWizardState.isOpen }
-                close={ closePolicyWizard }
-                initialValue={ policyWizardState.template }
-                showCreateStep={ policyWizardState.showCreateStep }
-                policiesExist={ getPoliciesQuery.hasPolicies === true }
-                isEditing={ policyWizardState.isEditing }
-            /> }
-            { policyToDelete.isOpen && <DeletePolicy
-                onClose={ listPageDelete.onCloseDeletePolicy }
-                onDeleted={ listPageDelete.onDeleted }
-                loading={ policyRows.loadingSelected }
-                count={ policyToDelete.count }
-                getPolicies={ policyRows.getSelected }
-                policy={ policyToDelete.policy }
-            />
+                    <Main>
+                        {getPoliciesQuery.hasPolicies === false ?
+                            (
+                                <ListPageEmptyState
+                                    createPolicy={ canWritePolicies ? toolbarActions.createCustomPolicy : undefined }
+                                />
+                            )
+                            : (
+                                <Section>
+                                    <PolicyToolbar
+                                        ouiaId="main-toolbar"
+                                        onCreatePolicy={ canWritePolicies ? toolbarActions.createCustomPolicy : undefined }
+                                        onDeletePolicy={ canWritePolicies ? toolbarActions.onDeletePolicies : undefined }
+                                        onEnablePolicy={ canWritePolicies ? toolbarActions.onEnablePolicies : undefined }
+                                        onDisablePolicy={ canWritePolicies ? toolbarActions.onDisablePolicies : undefined }
+                                        onPaginationChanged={ policyPage.changePage }
+                                        onPaginationSizeChanged={ policyPage.changeItemsPerPage }
+                                        onSelectionChanged={ policyRows.onSelectionChanged }
+                                        selectedCount={ policyRows.selectionCount }
+                                        page={ policyPage.page.index }
+                                        pageCount={ policyRows.rows.length }
+                                        perPage={ policyPage.page.size }
+                                        showPerPageOptions={ true }
+                                        filters={ policyFilters.filters }
+                                        setFilters= { policyFilters.setFilters }
+                                        clearFilters={ policyFilters.clearFilter }
+                                        count={ getPoliciesQueryCount }
+                                        onExport={ toolbarActions.onExport }
+                                        showBottomPagination={ true }
+                                    >
+                                        <PolicyTable
+                                            ouiaId="main-table"
+                                            policies={ policyRows.rows }
+                                            onCollapse={ policyRows.onCollapse }
+                                            onSelect={ policyRows.onSelect }
+                                            actionResolver={ tableActionsResolver }
+                                            loading={ isLoading }
+                                            error={ policyTableErrorValue }
+                                            onSort={ sort.onSort }
+                                            sortBy={ sort.sortBy }
+                                            linkToDetailPolicy={ true }
+                                        />
+                                    </PolicyToolbar>
+                                </Section>
+                            )}
+                    </Main>
+                    { policyWizardState.isOpen && <CreatePolicyWizard
+                        isOpen={ policyWizardState.isOpen }
+                        close={ closePolicyWizard }
+                        initialValue={ policyWizardState.template }
+                        showCreateStep={ policyWizardState.showCreateStep }
+                        policiesExist={ getPoliciesQuery.hasPolicies === true }
+                        isEditing={ policyWizardState.isEditing }
+                    /> }
+                    { policyToDelete.isOpen && <DeletePolicy
+                        onClose={ listPageDelete.onCloseDeletePolicy }
+                        onDeleted={ listPageDelete.onDeleted }
+                        loading={ policyRows.loadingSelected }
+                        count={ policyToDelete.count }
+                        getPolicies={ policyRows.getSelected }
+                        policy={ policyToDelete.policy }
+                    />
+                    }
+                </>
             }
+
         </>
     );
 };

--- a/test/AppWrapper.tsx
+++ b/test/AppWrapper.tsx
@@ -45,7 +45,7 @@ export const appWrapperSetup = () => {
     mock.onGet('/api/inventory/v1/hosts?page=1&per_page=1').reply(200,
         {
             total: 5,
-            count: 0,
+            count: 10,
             page: 1,
             per_page: 1,
             results: []


### PR DESCRIPTION
This moves around the logic for whats displayed regarding zero state. Mocks : https://www.sketch.com/s/550bd962-ca1f-42d8-8d89-d457527a059a/a/qbe9Ol2#Inspect 
Table page is unaffected : 
<img width="1014" alt="Screen Shot 2023-05-04 at 1 12 05 PM" src="https://user-images.githubusercontent.com/60629070/236277060-f599279c-06f8-485b-9838-1dec76fb3639.png">

ZeroState no longer displays "Policies" Title up top
<img width="1346" alt="Screen Shot 2023-05-04 at 1 12 49 PM" src="https://user-images.githubusercontent.com/60629070/236277226-84d9ee9f-61ee-4b20-aa11-edcb2843bb14.png">

This page is unaffected: 
<img width="1078" alt="Screen Shot 2023-05-04 at 1 13 53 PM" src="https://user-images.githubusercontent.com/60629070/236277446-c96832cc-6736-4ff5-aa32-8b32537cc119.png">
