### PR TITLE
fix(POL-729): replace broken link

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -32,7 +32,7 @@ const Config = {
         emailPreferences: () => localUrl('/user-preferences/notifications/insights', getInsights().chrome.isBeta()),
         notifications: () => localUrl('/settings/notifications/rhel', getInsights().chrome.isBeta()),
         // eslint-disable-next-line max-len
-        factsDocumentation: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/monitoring_and_reacting_to_configuration_changes_using_policies/assembly-policies-monitoring-appendix-ref-materials#ref-policies-monitoring-appendix-system-facts_policies-monitoring-appendix-ref-materials'
+        factsDocumentation: 'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/monitoring_and_reacting_to_configuration_changes_using_policies/policies-appendix_intro-policies#your-module-heading_policies-appendix'
     }
 };
 


### PR DESCRIPTION
In accordance to https://issues.redhat.com/browse/POL-729 (see comments), this updates the link in the 'create a policy' modal. 