### PR TITLE
Refactor Custom Route Component 'InsightsRoute' Before Upgrading to React Router v6

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -87,7 +87,7 @@ export const Routes: React.FunctionComponent<unknown> = () => {
                     path={ path }
                 />
             ))}
-            <Redirect to={ linkTo.listPage() } />
+            <Route render={() => <Redirect to={ linkTo.listPage() } />} />
         </Switch>
     );
 };

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -28,12 +28,14 @@ const pathRoutes: Path[] = [
     }
 ];
 
-type InsightsRouteProps = RouteProps;
+type InsightsElementProps = {
+    component: React.ComponentType;
+};
 
-const InsightsRoute: React.FunctionComponent<InsightsRouteProps> = (props: InsightsRouteProps) => {
+const InsightsElement: React.FunctionComponent<InsightsElementProps> = ({component: PathRouteComponent}) => {
     return (
         <ErrorPage>
-            <Route { ...props } />
+            <PathRouteComponent />
         </ErrorPage>
     );
 };
@@ -78,11 +80,11 @@ export const Routes: React.FunctionComponent<unknown> = () => {
 
     return (
         <Switch>
-            { pathRoutes.map(pathRoute => (
-                <InsightsRoute
-                    key={ pathRoute.path }
-                    component={ pathRoute.component }
-                    path={ pathRoute.path }
+            { pathRoutes.map(({ path, component }) => (
+                <Route
+                    key={ path }
+                    render={() => <InsightsElement component={ component } /> }
+                    path={ path }
                 />
             ))}
             <Redirect to={ linkTo.listPage() } />

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,7 +1,7 @@
 import { getBaseName, getInsights } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { useEffect } from 'react';
-import { matchPath, Redirect, Route, RouteProps, Switch, useHistory } from 'react-router';
+import { matchPath, Redirect, Route, Switch, useHistory } from 'react-router';
 
 import { ErrorPage } from './pages/Error/Page';
 import ListPage from './pages/ListPage/ListPage';
@@ -32,7 +32,7 @@ type InsightsElementProps = {
     component: React.ComponentType;
 };
 
-const InsightsElement: React.FunctionComponent<InsightsElementProps> = ({component: PathRouteComponent}) => {
+const InsightsElement: React.FunctionComponent<InsightsElementProps> = ({ component: PathRouteComponent }) => {
     return (
         <ErrorPage>
             <PathRouteComponent />
@@ -83,11 +83,11 @@ export const Routes: React.FunctionComponent<unknown> = () => {
             { pathRoutes.map(({ path, component }) => (
                 <Route
                     key={ path }
-                    render={() => <InsightsElement component={ component } /> }
+                    render={ () => <InsightsElement component={ component } /> }
                     path={ path }
                 />
             ))}
-            <Route render={() => <Redirect to={ linkTo.listPage() } />} />
+            <Route render={ () => <Redirect to={ linkTo.listPage() } /> } />
         </Switch>
     );
 };

--- a/src/__tests__/Routes.test.tsx
+++ b/src/__tests__/Routes.test.tsx
@@ -18,15 +18,14 @@ const getWrapper = (path: string) => {
     const Wrapper: React.FunctionComponent = (props) => {
         return (
             <MemoryRouter initialEntries={ [ path ] }>
-                <Route
-                    path="*"
-                    children={ ({ location }) => {
+                <Route path="*">
+                    {({ location }) => {
                         data.location = location;
                         return null;
-                    } }
-                />
+                    }}
+                </Route>
                 {/* eslint-disable-next-line testing-library/no-node-access */}
-                <div id="root">{ props.children }</div>
+                <div id="root">{props.children}</div>
             </MemoryRouter>
         );
     };
@@ -38,7 +37,6 @@ const getWrapper = (path: string) => {
 };
 
 describe('src/Routes', () => {
-
     it('Should render the ListPage on /', async () => {
         jest.useFakeTimers();
         const { Wrapper, data } = getWrapper('/');

--- a/src/__tests__/Routes.test.tsx
+++ b/src/__tests__/Routes.test.tsx
@@ -20,7 +20,7 @@ const getWrapper = (path: string) => {
             <MemoryRouter initialEntries={ [ path ] }>
                 <Route
                     path="*"
-                    render={ ({ location }) => {
+                    children={ ({ location }) => {
                         data.location = location;
                         return null;
                     } }


### PR DESCRIPTION
This refactor is needed according to the official migration guide
Here is a link to the relevant section:

https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v51 

What does this PR include ? 
- Refactor of InsightsRoute
https://reactrouter.com/en/main/upgrading/v5#refactor-custom-routes
- Convert Redirect to Route inside a Switch
https://reactrouter.com/en/main/upgrading/v5#remove-redirects-inside-switch 