### PR TITLE
chore(RHINENG-7853): Add OUIA id to create Policy wizard

### DIFF
--- a/src/components/Policy/PolicyWizard.tsx
+++ b/src/components/Policy/PolicyWizard.tsx
@@ -146,6 +146,7 @@ const FormikBinding: React.FunctionComponent<FormikBindingProps> = (props) => {
         <Form>
             <WizardContext.Provider value={ wizardContext }>
                 <Wizard
+                    data-ouia-component-id={ 'pendo-policy-wizard' }
                     isOpen={ true }
                     onSave={ onSave }
                     onClose={ props.onClose }

--- a/src/components/Policy/__tests__/PolicyWizard.test.tsx
+++ b/src/components/Policy/__tests__/PolicyWizard.test.tsx
@@ -23,6 +23,7 @@ describe('src/components/Policy/PolicyWizard', () => {
         jest.useFakeTimers();
         render(
             <PolicyWizard
+                data-ouia-component-id={ 'pendo-policy-wizard' }
                 initialValue={ {} }
                 onClose={ jest.fn() }
                 onSave={ jest.fn() }
@@ -47,6 +48,7 @@ describe('src/components/Policy/PolicyWizard', () => {
         jest.useFakeTimers();
         render(
             <PolicyWizard
+                data-ouia-component-id={ 'pendo-policy-wizard' }
                 initialValue={ {} }
                 onClose={ jest.fn() }
                 onSave={ jest.fn() }
@@ -71,6 +73,7 @@ describe('src/components/Policy/PolicyWizard', () => {
         jest.useFakeTimers();
         render(
             <PolicyWizard
+                data-ouia-component-id={ 'pendo-policy-wizard' }
                 initialValue={ {} }
                 onClose={ jest.fn() }
                 onSave={ jest.fn() }
@@ -98,6 +101,7 @@ describe('src/components/Policy/PolicyWizard', () => {
         jest.useFakeTimers();
         render(
             <PolicyWizard
+                data-ouia-component-id={ 'pendo-policy-wizard' }
                 initialValue={ {} }
                 onClose={ jest.fn() }
                 onSave={ jest.fn() }
@@ -133,6 +137,7 @@ describe('src/components/Policy/PolicyWizard', () => {
             jest.useFakeTimers();
             render(
                 <PolicyWizard
+                    data-ouia-component-id={ 'pendo-policy-wizard' }
                     initialValue={ {} }
                     onClose={ jest.fn() }
                     onSave={ jest.fn() }
@@ -155,6 +160,7 @@ describe('src/components/Policy/PolicyWizard', () => {
             jest.useFakeTimers();
             render(
                 <PolicyWizard
+                    data-ouia-component-id={ 'pendo-policy-wizard' }
                     initialValue={ {} }
                     onClose={ jest.fn() }
                     onSave={ jest.fn() }
@@ -182,6 +188,7 @@ describe('src/components/Policy/PolicyWizard', () => {
             const onValidateName = jest.fn(() => Promise.resolve({ created: false }));
             render(
                 <PolicyWizard
+                    data-ouia-component-id={ 'pendo-policy-wizard' }
                     initialValue={ {} }
                     onClose={ jest.fn() }
                     onSave={ jest.fn() }
@@ -215,6 +222,7 @@ describe('src/components/Policy/PolicyWizard', () => {
             const onValidateName = jest.fn(() => Promise.resolve({ created: false }));
             render(
                 <PolicyWizard
+                    data-ouia-component-id={ 'pendo-policy-wizard' }
                     initialValue={ {} }
                     onClose={ jest.fn() }
                     onSave={ jest.fn() }
@@ -252,6 +260,7 @@ describe('src/components/Policy/PolicyWizard', () => {
             const onValidateName = jest.fn(() => Promise.resolve({ created: false, error: 'invalid name' }));
             render(
                 <PolicyWizard
+                    data-ouia-component-id={ 'pendo-policy-wizard' }
                     initialValue={ {} }
                     onClose={ jest.fn() }
                     onSave={ jest.fn() }


### PR DESCRIPTION
This just adds an ouiaId to the policy wizard.

To test, just inspect the page and check the page for pendo-policy-wizard in a ctrl+f. 
Verify that its not there
Then open the policy wizard and see that the id populates and that it points to the entire wizard