### PR TITLE
chore(RHINENG-9387): update page titles

### DIFF
--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -207,7 +207,7 @@ const ListPage: React.FunctionComponent<unknown> = () => {
                 :
                 <>
                     <Helmet>
-                        <title>Policies - Operations | RHEL</title>
+                        <title>Policies - Operations</title>
                     </Helmet>
                     <PageHeader>
                         <PageHeaderTitle title={ Messages.pages.listPage.title } />

--- a/src/pages/ListPage/__tests__/ListPage.test.tsx
+++ b/src/pages/ListPage/__tests__/ListPage.test.tsx
@@ -391,6 +391,6 @@ describe('src/pages/ListPage', () => {
         });
 
         await waitForAsyncEvents();
-        expect(document.title).toEqual('Policies - Operations | RHEL');
+        expect(document.title).toEqual('Policies - Operations');
     });
 });

--- a/src/pages/PolicyDetail/PolicyDetail.tsx
+++ b/src/pages/PolicyDetail/PolicyDetail.tsx
@@ -157,7 +157,7 @@ export const PolicyDetail: React.FunctionComponent = () => {
     return (
         <>
             <Helmet>
-                <title>{ policy.name } - Policies - Operations | RHEL</title>
+                <title>{ policy.name } - Policies - Operations</title>
             </Helmet>
             <PageHeader>
                 <Stack>

--- a/src/pages/PolicyDetail/__tests__/PolicyDetail.test.tsx
+++ b/src/pages/PolicyDetail/__tests__/PolicyDetail.test.tsx
@@ -922,7 +922,7 @@ describe('src/Pages/PolicyDetail/PolicyDetail', () => {
         await waitForAsyncEvents();
     });
 
-    it('Title should be "{ name of policy } - Policies - Operations | RHEL"', async () => {
+    it('Title should be "{ name of policy } - Policies - Operations"', async () => {
         fetchMockSetup({
             policy: {
                 ...mockPolicy,
@@ -941,6 +941,6 @@ describe('src/Pages/PolicyDetail/PolicyDetail', () => {
         });
 
         await waitForAsyncEvents();
-        expect(document.title).toEqual('My Cool policy - Policies - Operations | RHEL');
+        expect(document.title).toEqual('My Cool policy - Policies - Operations');
     });
 });


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHINENG-9387

Updates page titles according to 'Current concept' column, single line treatment in this [sheet](https://docs.google.com/spreadsheets/d/1Uhwn6i9B383xUbnRQ2IWY3EZ6dihc-UfkHxnR_c7zXI/edit#gid=1001620868)