### PR TITLE
chore: Remove deprecated `Main` component

### DIFF
--- a/src/pages/ListPage/ListPage.tsx
+++ b/src/pages/ListPage/ListPage.tsx
@@ -1,5 +1,5 @@
 import { PageSection } from '@patternfly/react-core';
-import { ErrorState, Main, PageHeader, PageHeaderTitle, Section } from '@redhat-cloud-services/frontend-components';
+import { ErrorState, PageHeader, PageHeaderTitle, Section } from '@redhat-cloud-services/frontend-components';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { getInsights, InsightsEmailOptIn, Page, useSort } from '@redhat-cloud-services/insights-common-typescript';
 import axios from 'axios';
@@ -223,7 +223,7 @@ const ListPage: React.FunctionComponent<unknown> = () => {
                             />
                         </PageSection>
                     )}
-                    <Main>
+                    <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                         {getPoliciesQuery.hasPolicies === false ?
                             (
                                 <ListPageEmptyState
@@ -268,7 +268,7 @@ const ListPage: React.FunctionComponent<unknown> = () => {
                                     </PolicyToolbar>
                                 </Section>
                             )}
-                    </Main>
+                    </section>
                     { policyWizardState.isOpen && <CreatePolicyWizard
                         isOpen={ policyWizardState.isOpen }
                         close={ closePolicyWizard }

--- a/src/pages/NoPermissions/NoPermissionsPage.tsx
+++ b/src/pages/NoPermissions/NoPermissionsPage.tsx
@@ -1,5 +1,5 @@
 import { LockIcon } from '@patternfly/react-icons';
-import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import * as React from 'react';
 
 import { EmptyStateSection } from '../../components/Policy/EmptyState/Section';
@@ -10,12 +10,12 @@ export const NoPermissionsPage: React.FunctionComponent = () => (
         <PageHeader>
             <PageHeaderTitle title={ Messages.pages.noPermissions.title } />
         </PageHeader>
-        <Main>
+        <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
             <EmptyStateSection
                 icon={ LockIcon }
                 title={ Messages.pages.noPermissions.emptyState.title }
                 content={ Messages.pages.noPermissions.emptyState.content }
             />
-        </Main>
+        </section>
     </>
 );

--- a/src/pages/PolicyDetail/PolicyDetail.tsx
+++ b/src/pages/PolicyDetail/PolicyDetail.tsx
@@ -7,7 +7,7 @@ import {
     StackItem,
     Title
 } from '@patternfly/react-core';
-import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import { addDangerNotification, BreadcrumbLinkItem, Section } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { useContext } from 'react';
@@ -191,7 +191,7 @@ export const PolicyDetail: React.FunctionComponent = () => {
                     </StackItem>
                 </Stack>
             </PageHeader>
-            <Main>
+            <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                 <Section ouiaId="policy-detail" style={ { paddingBottom: '4px' } }>
                     <PolicyDetailIsEnabled
                         isEnabled={ policy.isEnabled }
@@ -212,7 +212,7 @@ export const PolicyDetail: React.FunctionComponent = () => {
                     policyId={ policyId }
                     ref={ triggerDetailRef }
                 />
-            </Main>
+            </section>
             { wizardState.data.isOpen && <CreatePolicyWizard
                 isOpen={ true }
                 close={ closePolicyWizard }

--- a/src/pages/PolicyDetail/Skeleton.tsx
+++ b/src/pages/PolicyDetail/Skeleton.tsx
@@ -8,7 +8,7 @@ import {
     Stack,
     StackItem } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
-import { Main, PageHeader, PageHeaderTitle, Spinner } from '@redhat-cloud-services/frontend-components';
+import { PageHeader, PageHeaderTitle, Spinner } from '@redhat-cloud-services/frontend-components';
 import { BreadcrumbLinkItem, Section } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { style } from 'typestyle';
@@ -46,13 +46,13 @@ export const PolicyDetailSkeleton: React.FunctionComponent = () => {
                     </StackItem>
                 </Stack>
             </PageHeader>
-            <Main>
+            <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                 <Section ouiaId="loading-spinner">
                     <Bullseye>
                         <Spinner centered />
                     </Bullseye>
                 </Section>
-            </Main>
+            </section>
         </>
     );
 };


### PR DESCRIPTION
Removes this error from the console
![Screenshot from 2024-07-02 20-04-50](https://github.com/RedHatInsights/policies-ui-frontend/assets/8426204/e619f557-045b-4ff4-a23e-2f201c679f9b)
