### PR TITLE
Tweaks to prepare for react-router-dom v6 migration

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,7 +1,7 @@
 import { getBaseName, getInsights } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { useEffect } from 'react';
-import { matchPath, Redirect, Route, Switch, useHistory } from 'react-router';
+import { matchPath, Redirect, Route, Switch, useHistory } from 'react-router-dom';
 
 import { ErrorPage } from './pages/Error/Page';
 import ListPage from './pages/ListPage/ListPage';

--- a/src/__tests__/Routes.test.tsx
+++ b/src/__tests__/Routes.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';
-import { Route } from 'react-router';
+import { Route } from 'react-router-dom';
 import { MemoryRouter } from 'react-router-dom';
 
 import { Routes } from '../Routes';

--- a/src/pages/Error/Page.tsx
+++ b/src/pages/Error/Page.tsx
@@ -1,13 +1,9 @@
 import { ErrorBoundary } from '@redhat-cloud-services/frontend-components';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { Messages } from '../../properties/Messages';
 
-type ErrorPageProps = RouteComponentProps<any>;
-
-export const ErrorPageInternal: React.FunctionComponent<ErrorPageProps> = (props) => {
-
+export const ErrorPage: React.FunctionComponent = (props) => {
     return (
         <ErrorBoundary
             headerTitle={ Messages.pages.error.title }
@@ -18,5 +14,3 @@ export const ErrorPageInternal: React.FunctionComponent<ErrorPageProps> = (props
         </ErrorBoundary>
     );
 };
-
-export const ErrorPage = withRouter(ErrorPageInternal);

--- a/src/pages/PolicyDetail/hooks/usePolicy.ts
+++ b/src/pages/PolicyDetail/hooks/usePolicy.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 // This seems to be stable enough:
 // https://github.com/facebook/react/issues/14259#issuecomment-505918440
 import { unstable_batchedUpdates } from 'react-dom';
-import { useHistory, useParams } from 'react-router';
+import { useHistory, useParams } from 'react-router-dom';
 import { usePrevious } from 'react-use';
 
 import { linkTo } from '../../../Routes';

--- a/src/pages/PolicyDetail/hooks/usePolicy.ts
+++ b/src/pages/PolicyDetail/hooks/usePolicy.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 // This seems to be stable enough:
 // https://github.com/facebook/react/issues/14259#issuecomment-505918440
 import { unstable_batchedUpdates } from 'react-dom';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { usePrevious } from 'react-use';
 
 import { linkTo } from '../../../Routes';
@@ -17,6 +17,7 @@ export const usePolicy = () => {
     }>();
     const prevPolicyIdFromUrl = usePrevious(policyIdFromUrl);
     const history = useHistory();
+    const location = useLocation();
     const [ policy, setPolicyInternal ] = React.useState<Policy>();
     const policyId = policy?.id || policyIdFromUrl;
 
@@ -41,7 +42,7 @@ export const usePolicy = () => {
                 setPolicyInternal(undefined);
             }
         }
-    }, [ policyIdFromUrl, prevPolicyIdFromUrl, batchPolicyUpdate, history, policy, policyId ]);
+    }, [ policyIdFromUrl, prevPolicyIdFromUrl, batchPolicyUpdate, location, policy, policyId ]);
 
     return {
         policyId,

--- a/test/AppWrapper.tsx
+++ b/test/AppWrapper.tsx
@@ -11,9 +11,7 @@ import { validateSchemaResponseInterceptor } from 'openapi2typescript/react-fetc
 import * as React from 'react';
 import { ClientContextProvider, createClient } from 'react-fetching-library';
 import { Provider } from 'react-redux';
-import { Route, RouteProps } from 'react-router';
-import { MemoryRouterProps, useLocation } from 'react-router';
-import { MemoryRouter as Router } from 'react-router-dom';
+import { MemoryRouter as Router, MemoryRouterProps, Route, RouteProps, useLocation } from 'react-router-dom';
 
 import { AppContext } from '../src/app/AppContext';
 


### PR DESCRIPTION
- Change 'react-router' to 'react-router-dom' -- 'react-router' is a subset of 'react-router-dom' which works with react-native as well and we shouldn't use it
- Remove the unused props from `ErrorPageInternal` along with removal of `withRouter`