### PR TITLE
fix(RHINENG-13389): Fix Policies table sorting

### DIFF
--- a/src/components/Policy/Table/PolicyTable.tsx
+++ b/src/components/Policy/Table/PolicyTable.tsx
@@ -225,7 +225,7 @@ export const PolicyTable: React.FunctionComponent<PolicyTableProps> = (props) =>
         }
     }, [ policies, onSelect ]);
 
-    const sortBy = React.useMemo<ISortBy | undefined>(() => {
+    const sortBy = React.useMemo<ISortBy>(() => {
         if (props.sortBy) {
             return {
                 index: indexForColumn(props.sortBy.column, columns, namedColumns, columnOffset),
@@ -233,7 +233,9 @@ export const PolicyTable: React.FunctionComponent<PolicyTableProps> = (props) =>
             };
         }
 
-        return undefined;
+        return {
+            defaultDirection: 'asc'
+        };
     }, [ props.sortBy, columns, namedColumns, columnOffset ]);
 
     const actionResolver = React.useMemo(() => props.error || props.loading ? undefined : props.actionResolver || undefined,


### PR DESCRIPTION
Fixes Policy table sorting.

Before:
```
chrome-root.93304c665f98ee3b.js:2 Uncaught TypeError: Cannot read properties of undefined (reading 'defaultDirection')
```
[Screencast from 2024-10-02 12-38-35.webm](https://github.com/user-attachments/assets/52f29195-1092-4703-aa3c-f7709777a6bb)

After:
[Screencast from 2024-10-02 12-38-54.webm](https://github.com/user-attachments/assets/80191b15-10ef-4ceb-9358-df72f6ac85d1)
