### PR TITLE
Revert "feat(RHINENG-22427): Remove routing from policies completely …

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -1,0 +1,83 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/RedHatInsights/frontend-components/refs/heads/master/packages/config-utils/src/feo/spec/frontend-crd.schema.json
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: policies-ui-frontend
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: Frontend
+    metadata:
+      name: policies
+    spec:
+      envName: ${ENV_NAME}
+      title: Policies
+      deploymentRepo: https://github.com/RedHatInsights/policies-ui-frontend
+      API:
+        versions:
+          - v1
+      frontend:
+        paths:
+          - /apps/policies
+      image: ${IMAGE}:${IMAGE_TAG}
+      feoConfigEnabled: true
+      serviceTiles:
+        - id: policies
+          section: operations
+          group: rhel
+          title: Policies
+          href: /insights/policies
+          description: Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.
+          icon: InsightsIcon
+      searchEntries:
+        - id: RHEL.policies
+          title: Policies
+          href: /insights/policies
+          description: Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.
+          alt_title:
+            - policies
+            - facts
+            - conditions
+            - trigger
+            - notifications
+            - alerts
+            - insights
+            - notify
+            - integration
+            - conditions
+            - events
+            - raise alerts on system configuration changes
+      bundleSegments:
+        - segmentId: operations
+          bundleId: insights
+          position: 200
+          navItems:
+            - id: operations
+              title: Operations
+              expandable: true
+              routes:
+                - id: policies
+                  title: Policies
+                  href: /insights/policies
+                  icon: InsightsIcon
+                  product: Red Hat Insights
+      module:
+        manifestLocation: /apps/policies/fed-mods.json
+        analytics:
+          APIKey: "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        config:
+          supportCaseData:
+            product: Red Hat Insights
+            version: Policies
+        modules:
+          - id: policies
+            module: ./RootApp
+            routes:
+              - pathname: /insights/policies
+              - pathname: /ansible/policies
+parameters:
+  - name: ENV_NAME
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE
+    value: quay.io/redhat-services-prod/insights-management-tenant/insights-policies/policies-ui-frontend

--- a/fec.config.js
+++ b/fec.config.js
@@ -48,5 +48,6 @@ module.exports = {
                 `/src/AppEntry`
             )
         }
-    }
+    },
+    frontendCRDPath: 'deploy/frontend.yml'
 };


### PR DESCRIPTION
…(#601)"

This reverts commit d745527d30d2f921b3ce3fb87e0e4d4209e72c13.

## Summary by Sourcery

Reintroduce frontend deployment configuration for the policies UI frontend and wire it into the project config.

Deployment:
- Add an OpenShift Template-based Frontend CRD manifest for the policies UI frontend, including navigation, search, and module configuration.
- Reference the new frontend CRD manifest from the frontend components configuration to enable deployment tooling integration.