### PR TITLE
feat(policies): disable FEO flag

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -1,5 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/RedHatInsights/frontend-components/refs/heads/master/packages/config-utils/src/feo/spec/frontend-crd.schema.json
-apiVersion: template.openshift.io/v1
+apiVersion: v1
 kind: Template
 metadata:
   name: policies-ui-frontend
@@ -19,61 +18,19 @@ objects:
         paths:
           - /apps/policies
       image: ${IMAGE}:${IMAGE_TAG}
-      feoConfigEnabled: true
-      serviceTiles:
-        - id: policies
-          section: operations
-          group: rhel
+      navItems:
+        - appId: policies
           title: Policies
           href: /insights/policies
-          description: Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.
-          icon: InsightsIcon
-      searchEntries:
-        - id: RHEL.policies
-          title: Policies
-          href: /insights/policies
-          description: Monitor your Red Hat Enterprise Linux inventory systems against set parameters to detect deviation or misalignment.
-          alt_title:
-            - policies
-            - facts
-            - conditions
-            - trigger
-            - notifications
-            - alerts
-            - insights
-            - notify
-            - integration
-            - conditions
-            - events
-            - raise alerts on system configuration changes
-      bundleSegments:
-        - segmentId: operations
-          bundleId: insights
-          position: 200
-          navItems:
-            - id: operations
-              title: Operations
-              expandable: true
-              routes:
-                - id: policies
-                  title: Policies
-                  href: /insights/policies
-                  icon: InsightsIcon
-                  product: Red Hat Insights
       module:
         manifestLocation: /apps/policies/fed-mods.json
-        analytics:
-          APIKey: "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
-        config:
-          supportCaseData:
-            product: Red Hat Insights
-            version: Policies
         modules:
           - id: policies
             module: ./RootApp
             routes:
               - pathname: /insights/policies
               - pathname: /ansible/policies
+        moduleID: policies
 parameters:
   - name: ENV_NAME
     required: true

--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -1,4 +1,5 @@
-apiVersion: v1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/RedHatInsights/frontend-components/refs/heads/master/packages/config-utils/src/feo/spec/frontend-crd.schema.json
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: policies-ui-frontend
@@ -18,19 +19,21 @@ objects:
         paths:
           - /apps/policies
       image: ${IMAGE}:${IMAGE_TAG}
-      navItems:
-        - appId: policies
-          title: Policies
-          href: /insights/policies
+      feoConfigEnabled: false
       module:
         manifestLocation: /apps/policies/fed-mods.json
+        analytics:
+          APIKey: "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+        config:
+          supportCaseData:
+            product: Red Hat Insights
+            version: Policies
         modules:
           - id: policies
             module: ./RootApp
             routes:
               - pathname: /insights/policies
               - pathname: /ansible/policies
-        moduleID: policies
 parameters:
   - name: ENV_NAME
     required: true

--- a/fec.config.js
+++ b/fec.config.js
@@ -48,5 +48,6 @@ module.exports = {
                 `/src/AppEntry`
             )
         }
-    }
+    },
+    frontendCRDPath: 'deploy/frontend.yml'
 };

--- a/fec.config.js
+++ b/fec.config.js
@@ -48,6 +48,5 @@ module.exports = {
                 `/src/AppEntry`
             )
         }
-    },
-    frontendCRDPath: 'deploy/frontend.yml'
+    }
 };


### PR DESCRIPTION
This reintroduces the removal of FE operator stuff

## Summary by Sourcery

Chores:
- Delete the deprecated frontend Kubernetes manifest and associated configuration path from the build config.